### PR TITLE
add front auth tests and manage existing email error

### DIFF
--- a/backend/src/resolvers/UserResolver.ts
+++ b/backend/src/resolvers/UserResolver.ts
@@ -52,7 +52,7 @@ class NewUserInput {
 function setCookie(ctx: Context, token: string) {
   ctx.res.setHeader(
     "Set-Cookie",
-    `eco-auth=${token};secure;httpOnly;SameSite=Strict;`
+    `eco-auth=${token};secure;httpOnly;SameSite=Strict;`,
   );
 }
 
@@ -102,6 +102,9 @@ export default class UserResolver {
         .flat();
       throw new Error(messages.join(", "));
     }
+
+    const existingUser = await User.findOneBy({ email: data.email });
+    if (existingUser) throw new Error("Email ou mot de passe invalide.");
 
     const hashedPassword = await argon2.hash(data.password);
     const username = data.email.split("@")[0];

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -73,7 +73,7 @@ export const LoginPage = () => {
             className={cn(
               "max-w-2xl w-full bg-white rounded-lg border shadow-md",
               "mx-auto flex flex-col items-start",
-              "gap-y-6 px-10 py-12"
+              "gap-y-6 px-10 py-12",
             )}
           >
             <TypographyH1 className="text-2xl font-semibold w-full text-center">
@@ -90,8 +90,11 @@ export const LoginPage = () => {
             </div>
 
             <div className="w-full">
-              <label className="text-sm block mb-1">Email</label>
+              <label htmlFor="login-email" className="text-sm block mb-1">
+                Email
+              </label>
               <Input
+                id="login-email"
                 name="email"
                 type="email"
                 value={email}
@@ -100,14 +103,17 @@ export const LoginPage = () => {
                 className={cn(
                   "block w-full rounded-md border bg-transparent border-gray-300",
                   "px-3 py-2 text-sm",
-                  "focus:outline-none focus:ring-2 focus:ring-primary"
+                  "focus:outline-none focus:ring-2 focus:ring-primary",
                 )}
                 required
               />
             </div>
             <div className="w-full">
-              <label className="text-sm block mb-1">Mot de passe</label>
+              <label htmlFor="login-password" className="text-sm block mb-1">
+                Mot de passe
+              </label>
               <Input
+                id="login-password"
                 name="password"
                 type="password"
                 value={password}
@@ -116,14 +122,16 @@ export const LoginPage = () => {
                 className={cn(
                   "block w-full rounded-md border bg-transparent border-gray-300",
                   "px-3 py-2 text-sm",
-                  "focus:outline-none focus:ring-2 focus:ring-primary"
+                  "focus:outline-none focus:ring-2 focus:ring-primary",
                 )}
                 required
               />
             </div>
 
             {errorMessage && (
-              <p className="text-destructive text-sm">{errorMessage}</p>
+              <p className="text-destructive text-sm" role="alert">
+                {errorMessage}
+              </p>
             )}
 
             <Button

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -77,7 +77,7 @@ export default function RegisterPage() {
     <li
       className={cn(
         "flex items-center gap-2 text-sm",
-        ok ? "text-green-600" : "text-gray-500"
+        ok ? "text-green-600" : "text-gray-500",
       )}
     >
       <span aria-hidden>{ok ? "✓" : "○"}</span>
@@ -93,7 +93,7 @@ export default function RegisterPage() {
             onSubmit={handleSubmit}
             className={cn(
               "bg-white",
-              "w-full max-w-2xl mx-auto flex flex-col items-start gap-y-6 rounded-lg border px-10 py-12 shadow-md"
+              "w-full max-w-2xl mx-auto flex flex-col items-start gap-y-6 rounded-lg border px-10 py-12 shadow-md",
             )}
           >
             <TypographyH1 className="text-2xl font-semibold w-full text-center">
@@ -121,7 +121,7 @@ export default function RegisterPage() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 className={cn(
-                  "block w-full rounded-md border px-3 py-2 text-sm bg-transparent focus:outline-none focus:ring-2 focus:ring-primary"
+                  "block w-full rounded-md border px-3 py-2 text-sm bg-transparent focus:outline-none focus:ring-2 focus:ring-primary",
                 )}
                 required
                 aria-invalid={email.length > 0 ? !emailValid : undefined}
@@ -140,7 +140,7 @@ export default function RegisterPage() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 className={cn(
-                  "block w-full rounded-md border px-3 py-2 text-sm bg-transparent focus:outline-none focus:ring-2 focus:ring-primary"
+                  "block w-full rounded-md border px-3 py-2 text-sm bg-transparent focus:outline-none focus:ring-2 focus:ring-primary",
                 )}
                 required
                 aria-describedby="password-hint"
@@ -160,7 +160,7 @@ export default function RegisterPage() {
                   {ruleItem(minLength, "Au moins 8 caractères")}
                   {ruleItem(
                     hasSpecialChar,
-                    "Au moins 1 caractère spécial (ex : ! @ # $ %)"
+                    "Au moins 1 caractère spécial (ex : ! @ # $ %)",
                   )}
                   {ruleItem(hasUpper, "Au moins 1 lettre majuscule")}
                   {ruleItem(hasLower, "Au moins 1 lettre minuscule")}
@@ -174,7 +174,9 @@ export default function RegisterPage() {
                 className="text-destructive text-sm w-full"
                 role="alert"
                 aria-live="assertive"
-              ></p>
+              >
+                {localError}
+              </p>
             )}
 
             <Button

--- a/frontend/src/pages/__tests__/LoginPage.integration.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.integration.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockedProvider } from "@apollo/client/testing";
+import { BrowserRouter } from "react-router";
+import { LoginPage } from "../LoginPage";
+import { LOGIN } from "@/graphql/mutations/login";
+import { useAuthStore } from "@/stores/authStore";
+
+// Create a mock function to spy on navigation calls
+const mockNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe("LoginPage - Integration Tests", () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      user: null,
+      isConnected: false,
+      isAuthLoading: false,
+    });
+    // Clear all mock navigate calls from previous tests
+    mockNavigate.mockClear();
+  });
+
+  it("should login with valid credentials", async () => {
+    // Setup user event instance for simulating interactions
+    const user = userEvent.setup();
+    const mockProfile = {
+      id: 1,
+      email: "user@example.com",
+      username: "user",
+    };
+
+    const mocks = [
+      {
+        // Mock the login mutation request
+        request: {
+          query: LOGIN,
+          variables: {
+            data: {
+              email: "user@example.com",
+              password: "ValidPass123!",
+            },
+          },
+        },
+        // Mock response from the server
+        result: {
+          data: {
+            login: JSON.stringify(mockProfile),
+          },
+        },
+      },
+    ];
+
+    // Render the component with mocked providers
+    render(
+      // Provide mocked Apollo Client
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <BrowserRouter>
+          <LoginPage />
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    // Fill the form
+    const emailInput = screen.getByLabelText(/email/i);
+    const passwordInput = screen.getByLabelText(/mot de passe/i);
+
+    await user.type(emailInput, "user@example.com");
+    await user.type(passwordInput, "ValidPass123!");
+
+    const submitButton = screen.getByRole("button", {
+      name: /se connecter/i,
+    });
+
+    expect(submitButton).not.toBeDisabled();
+
+    await user.click(submitButton);
+
+    // After successful login, should navigate to dashboard
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/dashboard");
+    });
+
+    // Verify that user is set in the store
+    await waitFor(() => {
+      const state = useAuthStore.getState();
+      expect(state.user).toEqual({
+        id: mockProfile.id,
+        email: mockProfile.email,
+        username: mockProfile.username,
+      });
+    });
+  });
+
+  it("should not login with invalid credentials", async () => {
+    const user = userEvent.setup();
+
+    const mocks = [
+      {
+        request: {
+          query: LOGIN,
+          variables: {
+            data: {
+              email: "wrong@example.com",
+              password: "WrongPass123!",
+            },
+          },
+        },
+        error: new Error("Email ou mot de passe invalide."),
+      },
+    ];
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <BrowserRouter>
+          <LoginPage />
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    const emailInput = screen.getByLabelText(/email/i);
+    const passwordInput = screen.getByLabelText(/mot de passe/i);
+
+    await user.type(emailInput, "wrong@example.com");
+    await user.type(passwordInput, "WrongPass123!");
+
+    const submitButton = screen.getByRole("button", {
+      name: /se connecter/i,
+    });
+
+    await user.click(submitButton);
+
+    // Verify that error message is displayed
+    await waitFor(() => {
+      expect(
+        screen.getByText(/email ou mot de passe invalide/i),
+      ).toBeInTheDocument();
+    });
+
+    // Verify that user is not created in the store
+    await waitFor(() => {
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.isConnected).toBe(false);
+    });
+
+    // Verify that navigation did not occur
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/__tests__/RegisterPage.integration.test.tsx
+++ b/frontend/src/pages/__tests__/RegisterPage.integration.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockedProvider } from "@apollo/client/testing";
+import { BrowserRouter } from "react-router";
+import RegisterPage from "../RegisterPage";
+import { SIGNUP_MUTATION } from "@/graphql/mutations/signup";
+import { useAuthStore } from "@/stores/authStore";
+
+// Create a mock function to spy on navigation calls
+const mockNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe("RegisterPage - Integration Tests", () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      user: null,
+      isConnected: false,
+      isAuthLoading: false,
+    });
+    // Clear all mock navigate calls from previous tests
+    mockNavigate.mockClear();
+  });
+
+  it("should create an account with valid data", async () => {
+    // Setup user event instance for simulating interactions
+    const user = userEvent.setup();
+    const mockProfile = {
+      id: 1,
+      email: "newuser@example.com",
+      username: "newuser",
+    };
+
+    const mocks = [
+      {
+        // Mock the signup mutation request
+        request: {
+          query: SIGNUP_MUTATION,
+          variables: {
+            data: {
+              email: "newuser@example.com",
+              password: "ValidPass123!",
+            },
+          },
+        },
+        // Mock response from the server
+        result: {
+          data: {
+            signup: JSON.stringify(mockProfile),
+          },
+        },
+      },
+    ];
+
+    // Render the component with mocked providers
+    render(
+      // Provide mocked Apollo Client
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <BrowserRouter>
+          <RegisterPage />
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    // Fill the form
+    const emailInput = screen.getByLabelText(/email/i);
+    const passwordInput = screen.getByLabelText(/mot de passe/i);
+
+    await user.type(emailInput, "newuser@example.com");
+    await user.type(passwordInput, "ValidPass123!");
+
+    const submitButton = screen.getByRole("button", {
+      name: /s'inscrire/i,
+    });
+
+    await waitFor(() => {
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    await user.click(submitButton);
+
+    // After successful signup, should navigate to dashboard
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/dashboard", {
+        replace: true,
+      });
+    });
+  });
+
+  it("should not create an account with existing data", async () => {
+    const user = userEvent.setup();
+
+    const mocks = [
+      {
+        request: {
+          query: SIGNUP_MUTATION,
+          variables: {
+            data: {
+              email: "existing@example.com",
+              password: "ValidPass123!",
+            },
+          },
+        },
+        error: new Error("Email ou mot de passe invalide."),
+      },
+    ];
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <BrowserRouter>
+          <RegisterPage />
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    const emailInput = screen.getByLabelText(/email/i);
+    const passwordInput = screen.getByLabelText(/mot de passe/i);
+
+    await user.type(emailInput, "existing@example.com");
+    await user.type(passwordInput, "ValidPass123!");
+
+    const submitButton = screen.getByRole("button", {
+      name: /s'inscrire/i,
+    });
+
+    await user.click(submitButton);
+
+    // Verify that error message is displayed
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /email ou mot de passe invalide/i,
+      );
+    });
+
+    // Verify that user is not created in the store
+    await waitFor(() => {
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.isConnected).toBe(false);
+    });
+
+    // Verify that navigation did not occur
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/stores/__tests__/authStore.unit.test.ts
+++ b/frontend/src/stores/__tests__/authStore.unit.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAuthStore } from "../authStore";
+
+describe("authStore - Unit Tests", () => {
+  beforeEach(() => {
+    // Reset store before each test using store actions
+    useAuthStore.getState().logout();
+    useAuthStore.getState().setAuthLoading(false);
+  });
+
+  describe("setUser", () => {
+    it("should set the user and isConnected to true", () => {
+      const mockUser = {
+        id: 1,
+        email: "test@example.com",
+        username: "testuser",
+      };
+
+      useAuthStore.getState().setUser(mockUser);
+
+      const state = useAuthStore.getState();
+      expect(state.user).toEqual(mockUser);
+      expect(state.isConnected).toBe(true);
+    });
+
+    it("should set isConnected to false when user is null", () => {
+      useAuthStore.getState().setUser(null);
+
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.isConnected).toBe(false);
+    });
+  });
+
+  describe("logout", () => {
+    it("should reset the user and isConnected", () => {
+      // Set an authenticated user
+      useAuthStore.getState().setUser({
+        id: 1,
+        email: "test@example.com",
+        username: "testuser",
+      });
+
+      // Log out
+      useAuthStore.getState().logout();
+
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.isConnected).toBe(false);
+    });
+  });
+
+  describe("Complete login/logout scenario", () => {
+    it("should handle a complete authentication cycle", () => {
+      // Initial state
+      let state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.isConnected).toBe(false);
+      expect(state.isAuthLoading).toBe(false);
+
+      // Start loading
+      useAuthStore.getState().setAuthLoading(true);
+      state = useAuthStore.getState();
+      expect(state.isAuthLoading).toBe(true);
+
+      // Successful login
+      const mockUser = {
+        id: 1,
+        email: "test@example.com",
+        username: "testuser",
+      };
+      useAuthStore.getState().setUser(mockUser);
+      useAuthStore.getState().setAuthLoading(false);
+
+      state = useAuthStore.getState();
+      expect(state.user).toEqual(mockUser);
+      expect(state.isConnected).toBe(true);
+      expect(state.isAuthLoading).toBe(false);
+
+      // Logout
+      useAuthStore.getState().logout();
+      state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.isConnected).toBe(false);
+    });
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
   test: {
     globals: true,
     setupFiles: ["./src/tests/setup.ts"],
     environment: "jsdom",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
   },
 });


### PR DESCRIPTION
# ❓Problem

<!-- Explain why this PR is needed (or link it to a notion task) -->
Tester les composants d'authentification en front grâce à des tests d'intégration vitest.


# 🎯 Solution

- Tests intégrations pour RegisterPage et LoginPage avec données valides et invalides,
- Tests unitaires pour authStore afin de tester le bon fonctionnement des méthodes du store,
- Modification du fichier vitest.config permettant d'utiliser le path aliases @,
- UserResolver : ajout logique de vérification pour utilisateur existant,
- RegisterPage : affichage de la localError
- LoginPage: ajout des htmlFor et id sur les Input afin de pouvoir les utiliser dans les tests,

# 🧭 Tests

<!--
If the changes in PR are not adequately covered by automated tests, describe how you manually tested them and to what extent (including edge cases)
-->
Les tests passent bien en local, en utilisant `npm run test` depuis le dossier /frontend.

# 🧑‍🎓 Checklist

- [ ] I have added visuals to help with the review (UI changes, test results, overview diagram, ...)
- [x] I have reviewed my own PR
