### PR TITLE
fix nested <a> issue

### DIFF
--- a/frontend/src/components/custom/Header/DesktopMenu.tsx
+++ b/frontend/src/components/custom/Header/DesktopMenu.tsx
@@ -19,7 +19,7 @@ const DesktopMenu = () => {
         {isConnected ? (
           <>
             <NavigationMenuItem>
-              <NavigationMenuLink>
+              <NavigationMenuLink asChild>
                 <NavLink
                   to="/dashboard"
                   className={({ isActive }) =>
@@ -41,7 +41,7 @@ const DesktopMenu = () => {
         ) : (
           <>
             <NavigationMenuItem>
-              <NavigationMenuLink>
+              <NavigationMenuLink asChild>
                 <NavLink
                   to="/signup"
                   className={({ isActive }) =>
@@ -53,7 +53,7 @@ const DesktopMenu = () => {
               </NavigationMenuLink>
             </NavigationMenuItem>
             <NavigationMenuItem>
-              <NavigationMenuLink>
+              <NavigationMenuLink asChild>
                 <NavLink
                   to="/signin"
                   className={({ isActive }) =>


### PR DESCRIPTION
## ✅ Description du problème
- Lors du rendu côté client, React signale une erreur d’hydratation : **`<a> cannot be a descendant of <a>`**.  
- Cause : `NavigationMenuLink` (Shadcn) rend un `<a>` et contient un `NavLink` (React Router) qui rend aussi un `<a>`, ce qui produit des balises `<a>` imbriquées invalides en HTML et provoque le mismatch serveur/client.  
- Zone impactée : DesktopMenu.tsx (menu desktop).

## 🔧 Solution mise en place et fonctionnement
- Changement : Ajout du prop **`asChild`** sur chaque `NavigationMenuLink` dans DesktopMenu.tsx.  
- Fonctionnement : avec `asChild`, Radix **ne rend plus son propre `<a>`** ; il transfère ses props au composant enfant (`NavLink`) qui devient seul élément d’ancrage. Cela évite l’imbrication `<a>` et la conséquence d’hydratation.  
- Vérification : `MobileMenuLink` utilisait déjà `asChild`, donc seul DesktopMenu.tsx nécessait la modification. Après correction, l’erreur d’hydratation disparaît normalement à l’exécution.