### PR TITLE
Upload challenge picture

### DIFF
--- a/backend/src/entities/Challenge.ts
+++ b/backend/src/entities/Challenge.ts
@@ -37,7 +37,7 @@ export class Challenge extends BaseEntity {
 
   @Column()
   @Field()
-  picture: string;
+  pictureUrl: string;
 
   @Column({ nullable: true })
   @Field({ nullable: true })

--- a/backend/src/lib/cloudinary.ts
+++ b/backend/src/lib/cloudinary.ts
@@ -6,6 +6,8 @@ cloudinary.config({
   api_secret: process.env.CLOUDINARY_API_SECRET,
 });
 
+const KNOWN_FOLDERS = ["profile_pictures", "challenge_pictures"];
+
 /**
  * Extract the public ID from a Cloudinary URL.
  * URL example: https://res.cloudinary.com/dy0orp9pn/image/upload/c_crop,x_100,y_50,w_300,h_300/c_fill,w_400,h_400,g_auto/profile_pictures/abc123.jpg
@@ -24,7 +26,7 @@ export function extractPublicIdFromUrl(url: string): string | null {
     const parts = publicId.split("/");
 
     const folderIndex = parts.findIndex(
-      (part) => !part.includes("_") || part === "profile_pictures",
+      (part) => !part.includes("_") || KNOWN_FOLDERS.includes(part),
     );
 
     if (folderIndex !== -1) {

--- a/backend/src/lib/cloudinary.ts
+++ b/backend/src/lib/cloudinary.ts
@@ -76,4 +76,30 @@ export function isDefaultAvatar(url: string): boolean {
   return url.includes("ui-avatars.com");
 }
 
+/**
+ * Attempts to delete an image from Cloudinary given its URL.
+ * Skips silently if the URL is not a Cloudinary URL.
+ * @param url - The Cloudinary image URL to delete.
+ * @param options.keepDefaultAvatars - If true, skip deletion when the URL is a default avatar.
+ */
+export async function tryDeleteCloudinaryImage(
+  url: string | null | undefined,
+  options: { keepDefaultAvatars?: boolean } = {},
+): Promise<void> {
+  if (!url || !isCloudinaryUrl(url)) return;
+  if (options.keepDefaultAvatars && isDefaultAvatar(url)) return;
+
+  const publicId = extractPublicIdFromUrl(url);
+
+  if (publicId) {
+    console.info(`Deleting old picture with public_id: ${publicId}`);
+    const deleted = await deleteImageFromCloudinary(publicId);
+    if (!deleted) {
+      console.warn(`Failed to delete old picture with public_id: ${publicId}`);
+    }
+  } else {
+    console.warn(`Could not extract public_id from URL: ${url}`);
+  }
+}
+
 export default cloudinary;

--- a/backend/src/resolvers/ChallengeResolver.ts
+++ b/backend/src/resolvers/ChallengeResolver.ts
@@ -11,12 +11,19 @@ import {
   Resolver,
 } from "type-graphql";
 import { In } from "typeorm";
-import { IsDate, IsNotEmpty, MinLength, validate } from "class-validator";
+import {
+  IsDate,
+  IsNotEmpty,
+  Matches,
+  MinLength,
+  validate,
+} from "class-validator";
 import { plainToClass, Type } from "class-transformer";
 import { Challenge } from "../entities/Challenge";
 import { Context } from "../types/Context";
 import { Ecogesture } from "../entities/Ecogesture";
 import { User } from "../entities/User";
+import { tryDeleteCloudinaryImage } from "../lib/cloudinary";
 
 @InputType()
 export class NewChallengeInput {
@@ -64,6 +71,19 @@ class GetMyChallengesInput {
 
   @Field(() => ChallengeFilter, { nullable: true })
   filter?: ChallengeFilter;
+}
+
+@InputType()
+class UpdateChallengePictureInput {
+  @Field()
+  id: number;
+
+  @Field()
+  @IsNotEmpty({ message: "L'URL de l'image ne peut pas être vide" })
+  @Matches(/^https?:\/\/.+/, {
+    message: "L'URL de l'image doit commencer par http:// ou https://",
+  })
+  pictureUrl: string;
 }
 
 // Filter for getMyChallenges (user point of view)
@@ -172,6 +192,41 @@ export default class ChallengeResolver {
       //TODO add participants
     });
 
+    await challenge.save();
+
+    return challenge;
+  }
+
+  @Authorized()
+  @Mutation(() => Challenge)
+  async updateChallengePicture(
+    @Arg("data") data: UpdateChallengePictureInput,
+    @Ctx() ctx: Context,
+  ) {
+    if (!ctx.user) {
+      throw new Error("Utilisateur non authentifié");
+    }
+
+    const challenge = await Challenge.findOne({
+      where: { id: data.id },
+      relations: ["createdBy"],
+    });
+
+    if (!challenge) {
+      throw new Error("Challenge non trouvé");
+    }
+
+    // Only the creator of the challenge can update its picture
+    if (challenge.createdBy.id !== ctx.user.id) {
+      throw new Error("Vous n'êtes pas autorisé à modifier ce challenge");
+    }
+
+    const oldPictureUrl = challenge.pictureUrl;
+
+    // If the old picture is stocked on Cloudinary, delete it from Cloudinary
+    await tryDeleteCloudinaryImage(oldPictureUrl);
+
+    challenge.pictureUrl = data.pictureUrl;
     await challenge.save();
 
     return challenge;

--- a/backend/src/resolvers/ChallengeResolver.ts
+++ b/backend/src/resolvers/ChallengeResolver.ts
@@ -10,7 +10,7 @@ import {
   registerEnumType,
   Resolver,
 } from "type-graphql";
-import { In } from "typeorm"; 
+import { In } from "typeorm";
 import { IsDate, IsNotEmpty, MinLength, validate } from "class-validator";
 import { plainToClass, Type } from "class-transformer";
 import { Challenge } from "../entities/Challenge";
@@ -39,7 +39,7 @@ export class NewChallengeInput {
   endingDate: Date;
 
   @Field()
-  picture: string;
+  pictureUrl: string;
 
   @Field(() => [Number], { nullable: true })
   ecogestureIds?: number[];
@@ -91,7 +91,7 @@ export default class ChallengeResolver {
   async getMyChallenges(
     @Ctx() ctx: Context,
     @Arg("input", () => GetMyChallengesInput, { nullable: true })
-    input?: GetMyChallengesInput
+    input?: GetMyChallengesInput,
   ): Promise<ChallengeListResponse> {
     if (!ctx.user) {
       throw new Error("Utilisateur non authentifié");
@@ -130,7 +130,7 @@ export default class ChallengeResolver {
   @Mutation(() => Challenge)
   async createChallenge(
     @Arg("data") data: NewChallengeInput,
-    @Ctx() ctx: Context
+    @Ctx() ctx: Context,
   ) {
     if (!ctx.user) {
       throw new Error("Utilisateur non authentifié");
@@ -152,7 +152,7 @@ export default class ChallengeResolver {
     let ecogestures: Ecogesture[] = [];
     if (data.ecogestureIds && data.ecogestureIds.length > 0) {
       ecogestures = await Ecogesture.findBy({ id: In(data.ecogestureIds) });
-      
+
       const uniqueEcogestureIds = Array.from(new Set(data.ecogestureIds));
       ecogestures = await Ecogesture.findByIds(uniqueEcogestureIds);
       // Vérifie que tous les IDs existent
@@ -165,15 +165,15 @@ export default class ChallengeResolver {
       label: data.label,
       startingDate: data.startingDate,
       endingDate: data.endingDate,
-      picture: data.picture,
-      description : data.description,
+      pictureUrl: data.pictureUrl,
+      description: data.description,
       createdBy: user,
       ecogestures: ecogestures,
       //TODO add participants
     });
 
     await challenge.save();
-    
+
     return challenge;
   }
 }

--- a/backend/src/resolvers/UserResolver.ts
+++ b/backend/src/resolvers/UserResolver.ts
@@ -20,12 +20,7 @@ import {
   validate,
 } from "class-validator";
 import { plainToClass } from "class-transformer";
-import {
-  deleteImageFromCloudinary,
-  extractPublicIdFromUrl,
-  isCloudinaryUrl,
-  isDefaultAvatar,
-} from "../lib/cloudinary";
+import { tryDeleteCloudinaryImage } from "../lib/cloudinary";
 
 @InputType()
 class NewUserInput {
@@ -198,29 +193,7 @@ export default class UserResolver {
     const oldPictureUrl = user.pictureUrl;
 
     // If the old picture is not a default avatar, delete it from Cloudinary
-    if (
-      oldPictureUrl &&
-      isCloudinaryUrl(oldPictureUrl) &&
-      !isDefaultAvatar(oldPictureUrl)
-    ) {
-      const publicId = extractPublicIdFromUrl(oldPictureUrl);
-
-      if (publicId) {
-        console.info(
-          `Deleting old profile picture with public_id: ${publicId}`,
-        );
-
-        const deleted = await deleteImageFromCloudinary(publicId);
-
-        if (!deleted) {
-          console.warn(
-            `Failed to delete old profile picture with public_id: ${publicId}`,
-          );
-        }
-      } else {
-        console.warn(`Could not extract public_id from URL: ${oldPictureUrl}`);
-      }
-    }
+    await tryDeleteCloudinaryImage(oldPictureUrl, { keepDefaultAvatars: true });
 
     user.pictureUrl = data.pictureUrl;
     await user.save();

--- a/frontend/src/generated/graphql-types.ts
+++ b/frontend/src/generated/graphql-types.ts
@@ -28,7 +28,7 @@ export type Challenge = {
   id: Scalars['Float']['output'];
   label: Scalars['String']['output'];
   participants: Array<UserChallenge>;
-  picture: Scalars['String']['output'];
+  pictureUrl: Scalars['String']['output'];
   startingDate: Scalars['DateTimeISO']['output'];
   updatedAt: Scalars['DateTimeISO']['output'];
 };
@@ -120,7 +120,7 @@ export type NewChallengeInput = {
   ecogestureIds?: InputMaybe<Array<Scalars['Float']['input']>>;
   endingDate: Scalars['DateTimeISO']['input'];
   label: Scalars['String']['input'];
-  picture: Scalars['String']['input'];
+  pictureUrl: Scalars['String']['input'];
   startingDate: Scalars['DateTimeISO']['input'];
 };
 
@@ -213,7 +213,7 @@ export type CreateChallengeMutationVariables = Exact<{
 }>;
 
 
-export type CreateChallengeMutation = { __typename?: 'Mutation', createChallenge: { __typename?: 'Challenge', id: number, label: string, description?: string | null, startingDate: any, endingDate: any, picture: string, createdBy: { __typename?: 'User', id: number, username: string }, ecogestures?: Array<{ __typename?: 'Ecogesture', id: number, label: string, pictureUrl: string }> | null } };
+export type CreateChallengeMutation = { __typename?: 'Mutation', createChallenge: { __typename?: 'Challenge', id: number, label: string, description?: string | null, startingDate: any, endingDate: any, pictureUrl: string, createdBy: { __typename?: 'User', id: number, username: string }, ecogestures?: Array<{ __typename?: 'Ecogesture', id: number, label: string, pictureUrl: string }> | null } };
 
 export type SeedEcogesturesMutationVariables = Exact<{ [key: string]: never; }>;
 
@@ -256,7 +256,7 @@ export type GetMyChallengesQueryVariables = Exact<{
 }>;
 
 
-export type GetMyChallengesQuery = { __typename?: 'Query', getMyChallenges: { __typename?: 'ChallengeListResponse', totalCount: number, challenges: Array<{ __typename?: 'Challenge', id: number, label: string, startingDate: any, endingDate: any, picture: string, createdBy: { __typename?: 'User', id: number, username: string }, participants: Array<{ __typename?: 'UserChallenge', id: number }> }> } };
+export type GetMyChallengesQuery = { __typename?: 'Query', getMyChallenges: { __typename?: 'ChallengeListResponse', totalCount: number, challenges: Array<{ __typename?: 'Challenge', id: number, label: string, startingDate: any, endingDate: any, pictureUrl: string, createdBy: { __typename?: 'User', id: number, username: string }, participants: Array<{ __typename?: 'UserChallenge', id: number }> }> } };
 
 export type GetEcogesturesQueryVariables = Exact<{
   input?: InputMaybe<GetEcogesturesInput>;
@@ -294,7 +294,7 @@ export const CreateChallengeDocument = gql`
     description
     startingDate
     endingDate
-    picture
+    pictureUrl
     createdBy {
       id
       username
@@ -537,7 +537,7 @@ export const GetMyChallengesDocument = gql`
       label
       startingDate
       endingDate
-      picture
+      pictureUrl
       createdBy {
         id
         username

--- a/frontend/src/graphql/mutations/challenge.ts
+++ b/frontend/src/graphql/mutations/challenge.ts
@@ -21,3 +21,13 @@ export const CREATE_CHALLENGE = gql`
     }
   }
 `;
+
+export const UPDATE_CHALLENGE_PICTURE = gql`
+  mutation UpdateChallengePicture($data: UpdateChallengePictureInput!) {
+    updateChallengePicture(data: $data) {
+      id
+      label
+      pictureUrl
+    }
+  }
+`;

--- a/frontend/src/graphql/mutations/challenge.ts
+++ b/frontend/src/graphql/mutations/challenge.ts
@@ -1,4 +1,4 @@
-import {gql} from "@apollo/client";
+import { gql } from "@apollo/client";
 
 export const CREATE_CHALLENGE = gql`
   mutation CreateChallenge($data: NewChallengeInput!) {
@@ -8,7 +8,7 @@ export const CREATE_CHALLENGE = gql`
       description
       startingDate
       endingDate
-      picture
+      pictureUrl
       createdBy {
         id
         username

--- a/frontend/src/graphql/queries/challenge.ts
+++ b/frontend/src/graphql/queries/challenge.ts
@@ -8,7 +8,7 @@ export const GET_MY_CHALLENGES = gql`
         label
         startingDate
         endingDate
-        picture
+        pictureUrl
         createdBy {
           id
           username

--- a/frontend/src/hooks/useCloudinaryWidget.ts
+++ b/frontend/src/hooks/useCloudinaryWidget.ts
@@ -29,6 +29,8 @@ interface UseCloudinaryWidgetOptions {
   uploadPreset: string;
   onSuccess: (url: string) => void;
   onError?: (error: Error) => void;
+  folder: string;
+  croppingAspectRatio: number;
 }
 
 // Extend the Window interface for Typescript to include Cloudinary
@@ -61,6 +63,8 @@ export function useCloudinaryWidget({
   uploadPreset,
   onSuccess,
   onError,
+  folder,
+  croppingAspectRatio,
 }: UseCloudinaryWidgetOptions) {
   // useCallback to memoize the openWidget function and avoid unnecessary re-creations
   const openWidget = useCallback(() => {
@@ -78,9 +82,9 @@ export function useCloudinaryWidget({
         sources: ["local", "camera"], // Allow uploads from local files and camera
         multiple: false, // Only one file accepted
         maxFiles: 1,
-        folder: "profile_pictures", // Organize uploads in a specific folder of Cloudinary
+        folder, // Organize uploads in a specific folder of Cloudinary
         cropping: true, // Active cropping editor in the widget
-        croppingAspectRatio: 1, // Force square aspect ratio for profile pictures
+        croppingAspectRatio, // Force square aspect ratio for profile pictures
         croppingShowDimensions: true, // Show dimensions while cropping
         croppingCoordinatesMode: "custom", // Use custom coordinates for cropping
         showSkipCropButton: false, // Don't allow skipping the crop step

--- a/frontend/src/hooks/useCloudinaryWidget.ts
+++ b/frontend/src/hooks/useCloudinaryWidget.ts
@@ -105,8 +105,13 @@ export function useCloudinaryWidget({
             const [coords] = coordinates.custom;
             const { public_id } = result.info;
 
+            const dimensions = {
+              width: croppingAspectRatio === 1 ? 400 : 600,
+              height: croppingAspectRatio === 1 ? 400 : 300,
+            };
+
             // Build URL with crop transformation applied
-            const croppedUrl = `https://res.cloudinary.com/${cloudName}/image/upload/c_crop,x_${coords[0]},y_${coords[1]},w_${coords[2]},h_${coords[3]}/c_fill,w_400,h_400,g_auto/${public_id}`;
+            const croppedUrl = `https://res.cloudinary.com/${cloudName}/image/upload/c_crop,x_${coords[0]},y_${coords[1]},w_${coords[2]},h_${coords[3]}/c_fill,w_${dimensions.width},h_${dimensions.height},g_auto/${public_id}`;
             onSuccess(croppedUrl);
           } else {
             // Fallback to original URL if no crop coordinates
@@ -119,7 +124,14 @@ export function useCloudinaryWidget({
     );
 
     widget.open();
-  }, [cloudName, uploadPreset, onSuccess, onError]);
+  }, [
+    cloudName,
+    uploadPreset,
+    onSuccess,
+    onError,
+    folder,
+    croppingAspectRatio,
+  ]);
 
   return { openWidget };
 }

--- a/frontend/src/pages/CreateChallengePage/NewChallenge.tsx
+++ b/frontend/src/pages/CreateChallengePage/NewChallenge.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { useMutation } from "@apollo/client";
+import { ApolloError, useMutation } from "@apollo/client";
 import { useNavigate } from "react-router";
 import { CREATE_CHALLENGE } from "@/graphql/mutations/challenge";
 import { GET_MY_CHALLENGES } from "@/graphql/queries/challenge";
@@ -111,9 +111,12 @@ function NewChallenge({
       setSelectedEcogestures([]);
       setParticipants([]);
       navigate("/dashboard");
-    } catch (err: any) {
-      // TODO: Handle err any type properly
-      console.error("Error:", err);
+    } catch (err) {
+      if (err instanceof ApolloError) {
+        console.error("Apollo error:", err.graphQLErrors, err.networkError);
+      } else if (err instanceof Error) {
+        console.error("Error:", err.message);
+      }
     }
   };
 

--- a/frontend/src/pages/CreateChallengePage/NewChallenge.tsx
+++ b/frontend/src/pages/CreateChallengePage/NewChallenge.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useMutation } from "@apollo/client";
 import { useNavigate } from "react-router";
 import { CREATE_CHALLENGE } from "@/graphql/mutations/challenge";
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { X, User, Upload } from "lucide-react";
 import { CalendarPopover } from "@/components/ui/calendar";
 import { type DateRange } from "react-day-picker";
+import { useCloudinaryWidget } from "@/hooks/useCloudinaryWidget";
 
 function NewChallenge({
   selectedEcogestures,
@@ -33,7 +34,7 @@ function NewChallenge({
     description: "",
     startingDate: "",
     endingDate: "",
-    picture: "",
+    pictureUrl: "",
   });
   const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
   const [participants, setParticipants] = useState<string[]>([]);
@@ -57,23 +58,30 @@ function NewChallenge({
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
-  // // Upload image (placeholder)
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files[0]) {
-      // Pour l'instant, on utilise un preview local
-      const url = URL.createObjectURL(e.target.files[0]);
-      setForm({ ...form, picture: url });
-    }
-  };
+  const handleUploadSuccess = useCallback((pictureUrl: string) => {
+    setForm((prev) => ({ ...prev, pictureUrl }));
+  }, []);
 
-  // // Ajout participant
+  const { openWidget } = useCloudinaryWidget({
+    cloudName: import.meta.env.VITE_CLOUDINARY_CLOUD_NAME,
+    uploadPreset: import.meta.env.VITE_CLOUDINARY_UPLOAD_PRESET,
+    folder: "challenge_pictures", // Dedicated folder for challenge images in Cloudinary
+    croppingAspectRatio: 16 / 9,
+    onSuccess: handleUploadSuccess,
+    onError: (error) => {
+      console.error("Cloudinary upload error:", error);
+      alert("Erreur lors du téléchargement de l'image. Veuillez réessayer.");
+    },
+  });
+
+  // Add participant
   const handleAddParticipant = () => {
     if (participantInput && !participants.includes(participantInput)) {
       setParticipants([...participants, participantInput]);
       setParticipantInput("");
     }
   };
-  // // Suppression participant
+  // Remove participant
   const handleRemoveParticipant = (name: string) => {
     setParticipants(participants.filter((p) => p !== name));
   };
@@ -86,7 +94,7 @@ function NewChallenge({
         description: form.description,
         startingDate: new Date(form.startingDate).toISOString(),
         endingDate: new Date(form.endingDate).toISOString(),
-        picture: form.picture,
+        pictureUrl: form.pictureUrl,
         ecogestureIds: selectedEcogestures.map(Number),
       },
     };
@@ -98,12 +106,13 @@ function NewChallenge({
         description: "",
         startingDate: "",
         endingDate: "",
-        picture: "",
+        pictureUrl: "",
       });
       setSelectedEcogestures([]);
       setParticipants([]);
       navigate("/dashboard");
     } catch (err: any) {
+      // TODO: Handle err any type properly
       console.error("Error:", err);
     }
   };
@@ -114,28 +123,20 @@ function NewChallenge({
         <Card className="overflow-hidden p-0 bg-primary-foreground w-full">
           <div className="w-full h-40 sm:h-56 md:h-72 relative flex items-center justify-center">
             <img
-              src={form.picture || "https://picsum.photos/600/400"}
+              src={form.pictureUrl || "https://picsum.photos/600/400"}
               alt="Challenge preview"
               className="object-cover w-full h-full"
             />
             <div className="absolute bottom-2 left-1/2 -translate-x-1/2">
-              <label htmlFor="picture-upload">
-                <Button
-                  type="button"
-                  variant="secondary"
-                  className="flex items-center gap-2"
-                >
-                  <Upload size={18} />
-                  Charger une photo
-                </Button>
-                <input
-                  id="picture-upload"
-                  type="file"
-                  accept="image/*"
-                  className="hidden"
-                  onChange={handleImageChange}
-                />
-              </label>
+              <Button
+                type="button"
+                variant="secondary"
+                className="flex items-center gap-2"
+                onClick={openWidget}
+              >
+                <Upload size={18} />
+                Charger une photo
+              </Button>
             </div>
           </div>
         </Card>

--- a/frontend/src/pages/DashboardPage/MyChallenges.tsx/ChallengeCard.tsx
+++ b/frontend/src/pages/DashboardPage/MyChallenges.tsx/ChallengeCard.tsx
@@ -32,12 +32,12 @@ const ChallengeCard = ({ challenge, userId }: ChallengeCardProps) => {
     <Card
       className={cn(
         "w-full overflow-hidden pt-0",
-        "bg-secondary-foreground border-none shadow-2xl"
+        "bg-secondary-foreground border-none shadow-2xl",
       )}
     >
       <div className="relative h-48 overflow-hidden">
         <img
-          src={challenge.picture}
+          src={challenge.pictureUrl}
           alt="Photo du challenge"
           className="w-full h-full object-cover"
         />
@@ -45,7 +45,7 @@ const ChallengeCard = ({ challenge, userId }: ChallengeCardProps) => {
           className={cn(
             "absolute top-3 right-3",
             "bg-white/90 p-2 rounded-lg shadow-md",
-            "flex gap-2"
+            "flex gap-2",
           )}
         >
           {challenge.createdBy.id === userId && (

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -49,6 +49,8 @@ function ProfilePage() {
   const { openWidget } = useCloudinaryWidget({
     cloudName: import.meta.env.VITE_CLOUDINARY_CLOUD_NAME,
     uploadPreset: import.meta.env.VITE_CLOUDINARY_UPLOAD_PRESET,
+    folder: "profile_pictures",
+    croppingAspectRatio: 1,
     onSuccess: handleUploadSuccess,
     onError: (error) => {
       console.error("Erreur du widget Cloudinary :", error);

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useMutation } from "@apollo/client";
+import { ApolloError, useMutation } from "@apollo/client";
 import { SIGNUP_MUTATION } from "@/graphql/mutations/signup";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -69,8 +69,12 @@ export default function RegisterPage() {
         return;
       }
       navigate("/dashboard", { replace: true });
-    } catch (err: any) {
-      setLocalError(err?.message || "Erreur réseau");
+    } catch (err: unknown) {
+      if (err instanceof ApolloError) {
+        setLocalError(err.message);
+      } else {
+        setLocalError("Erreur réseau");
+      }
     }
   };
 


### PR DESCRIPTION
# ❓Problème

La page de création de challenge utilisait provisoirement un simple `<input type="file">` local pour l'image, sans réel upload vers Cloudinary. De plus, le hook `useCloudinaryWidget` était codé en dur pour les photos de profil (dossier et ratio d'aspect fixes), empêchant toute réutilisation pour d'autres contextes. Enfin, il n'existait aucune mutation pour modifier l'image d'un challenge après sa création.

# 🎯 Solution

**Refactoring du hook `useCloudinaryWidget`**
Les paramètres folder et croppingAspectRatio, jusqu'ici codés en dur ("profile_pictures" et 1), sont maintenant exposés comme options obligatoires du hook. Les dimensions de sortie s'adaptent automatiquement au ratio (400×400 pour 1:1, 600×300 pour 16:9).

**Intégration Cloudinary dans la création de challenge**
Le faux `<input type="file">` est remplacé par l'ouverture du widget Cloudinary, avec un dossier challenge_pictures dédié et un recadrage 16:9. Le champ picture est renommé pictureUrl pour cohérence avec les autres entités.

**Nouvelle mutation updateChallengePicture**
Ajout côté backend d'une mutation protégée permettant au créateur d'un challenge de remplacer son image. L'ancienne image est automatiquement supprimée de Cloudinary avant la mise à jour.

**Utilitaire tryDeleteCloudinaryImage**
La logique répétée de suppression d'image Cloudinary (extraction du public_id, appel de suppression, gestion des logs) est factorisée dans une fonction partagée utilisée à la fois par UserResolver et ChallengeResolver.


# 🧭 Tests

**Manuel:**
Création d'un challenge avec upload d'image via le widget Cloudinary : vérification de l'aperçu et de l'enregistrement en base avec l'URL Cloudinary.
