### PR TITLE
21 filter challenge participant

### DIFF
--- a/backend/src/resolvers/ChallengeResolver.ts
+++ b/backend/src/resolvers/ChallengeResolver.ts
@@ -122,9 +122,12 @@ export default class ChallengeResolver {
     } else if (filter === ChallengeFilter.IN_PROGRESS) {
       queryBuilder
         .where("challenge.startingDate <= :now", { now })
-        .andWhere("challenge.endingDate >= :now", { now });
+        .andWhere("challenge.endingDate >= :now", { now })
+        .andWhere("participants.userId = :userId", { userId: ctx.user.id });
     } else if (filter === ChallengeFilter.FINISHED) {
-      queryBuilder.where("challenge.endingDate < :now", { now });
+      queryBuilder
+        .where("challenge.endingDate < :now", { now })
+        .andWhere("participants.userId = :userId", { userId: ctx.user.id });
     }
     const [challenges, totalCount] = await queryBuilder.getManyAndCount();
 

--- a/frontend/src/components/custom/Header/useAuthMenuActions.ts
+++ b/frontend/src/components/custom/Header/useAuthMenuActions.ts
@@ -1,6 +1,7 @@
 import { useLogoutMutation } from "@/generated/graphql-types";
 import { useNavigate } from "react-router";
 import { useAuthStore } from "@/stores/authStore";
+import { useApolloClient } from "@apollo/client";
 
 export function useAuthMenuActions() {
   const [logout] = useLogoutMutation();
@@ -8,11 +9,17 @@ export function useAuthMenuActions() {
   const isConnected = useAuthStore((state) => state.isConnected);
   const logoutStore = useAuthStore((state) => state.logout);
   const userPictureUrl = useAuthStore((state) => state.user?.pictureUrl);
+  const client = useApolloClient();
 
   const handleLogout = async () => {
-    await logout();
-    logoutStore();
-    navigate("/");
+    try {
+      await logout();
+      await client.clearStore();
+      logoutStore();
+      navigate("/");
+    } catch (error) {
+      console.error("Erreur:", error);
+    }
   };
 
   return { isConnected, handleLogout, userPictureUrl };


### PR DESCRIPTION
<!-- Keep the structure intact, only attempt to replace the comments based on their content, with the exception of this comment, which should not be replaced -->

# ❓Problem

<!-- Explain why this PR is needed (or link it to a notion task) -->
Lié au ticket : 21 En tant qu'utilisateur, dans la page dashboard, je veux pouvoir retrouver seulement mes challenges dans le filtre "en cours". Et non les challenges globaux en cours

# 🎯 Solution

<!-- Ask yourself the following questions to provide the right level of detail, and summarize what you would answer: -->
<!-- "What context do I need to provide to the reviewer (or myself if I come back to this PR 3 months later) so they have what is necessary and sufficient to review the PR efficiently?" -->
<!-- "What kind of questions would I get on this PR if I didn't explain anything?" -->
<!-- "What problem(s) may this PR cause after deploying in production? + How will the team know if such problem(s) happen?" -->
<!-- If nothing stands out from these questions, you can leave this section empty  -->
<!-- If you need to provide technical insights, add a link to the technical documentation in notion  -->
- Dans la query ajout d'un filtre pour vérifier que le user est dans les participants du challenge

Pb secondaire : quand on se déconnectait pour se connecter avec un autre compte on pouvait voir les challenges de l'utilisateur précédents.

Solution : Effacer le cache ApolloClient au moment du logout 

# 🧭 Tests

<!--
If the changes in PR are not adequately covered by automated tests, describe how you manually tested them and to what extent (including edge cases)
-->

# 🧑‍🎓 Checklist

- [ ] I have added visuals to help with the review (UI changes, test results, overview diagram, ...)
- [x] I have reviewed my own PR
