### PR TITLE
7.2 progress bar

### DIFF
--- a/backend/src/entities/Challenge.ts
+++ b/backend/src/entities/Challenge.ts
@@ -15,6 +15,7 @@ import {
 import { User } from "./User";
 import { UserChallenge } from "./UserChallenge";
 import { Ecogesture } from "./Ecogesture";
+import { Expose } from "class-transformer";
 
 @Entity()
 @ObjectType()
@@ -63,4 +64,8 @@ export class Challenge extends BaseEntity {
   @UpdateDateColumn()
   @Field()
   updatedAt: Date;
+
+  @Field(() => Number, { nullable: true })
+  @Expose()
+  progressPercentage: number = 0;
 }

--- a/backend/src/resolvers/ChallengeResolver.ts
+++ b/backend/src/resolvers/ChallengeResolver.ts
@@ -3,12 +3,14 @@ import {
   Authorized,
   Ctx,
   Field,
+  FieldResolver,
   InputType,
   Mutation,
   ObjectType,
   Query,
   registerEnumType,
   Resolver,
+  Root,
 } from "type-graphql";
 import { In } from "typeorm";
 import {
@@ -26,6 +28,7 @@ import { User } from "../entities/User";
 import { tryDeleteCloudinaryImage } from "../lib/cloudinary";
 import { UserChallenge } from "../entities/UserChallenge";
 import dataSource from "../config/db";
+import { UserEcogesture } from "../entities/UserEcogesture";
 
 @InputType()
 export class NewChallengeInput {
@@ -105,6 +108,43 @@ registerEnumType(ChallengeFilter, {
 
 @Resolver(Challenge)
 export default class ChallengeResolver {
+  @FieldResolver(() => Number) // ← Ajoute un champ virtuel
+  async progressPercentage(@Root() challenge: Challenge): Promise<number> {
+    //nb ecogeste validé
+
+    const fullChallenge = await Challenge.findOne({
+      where: { id: challenge.id },
+      relations: ["participants", "ecogestures"],
+    });
+
+    if (!fullChallenge) {
+      throw new Error("Challenge non trouvé");
+    }
+
+    const totalEcogestures = fullChallenge.ecogestures?.length || 0;
+    const totalParticipants = fullChallenge.participants?.length || 0;
+
+    if (totalEcogestures === 0 || totalParticipants === 0) {
+      return 0; // Évite la division par zéro
+    }
+
+    const ecogestureIds = fullChallenge.ecogestures?.map((e) => e.id) || [];
+    const participantIds =
+      fullChallenge.participants?.map((p) => p.user.id) || [];
+
+    // Compter combien de fois les participants ont validé les écogestes du challenge
+    const totalValidations = await UserEcogesture.count({
+      where: {
+        user: { id: In(participantIds) },
+        ecogesture: { id: In(ecogestureIds) },
+      },
+    });
+
+    const maxPossibleValidations = totalEcogestures * totalParticipants;
+
+    return Math.round((totalValidations / maxPossibleValidations) * 100);
+  }
+
   @Query(() => [Challenge])
   async getAllChallenges() {
     const challenges = await Challenge.find();

--- a/backend/src/resolvers/ChallengeResolver.ts
+++ b/backend/src/resolvers/ChallengeResolver.ts
@@ -3,14 +3,12 @@ import {
   Authorized,
   Ctx,
   Field,
-  FieldResolver,
   InputType,
   Mutation,
   ObjectType,
   Query,
   registerEnumType,
   Resolver,
-  Root,
 } from "type-graphql";
 import { In } from "typeorm";
 import {
@@ -108,8 +106,9 @@ registerEnumType(ChallengeFilter, {
 
 @Resolver(Challenge)
 export default class ChallengeResolver {
-  @FieldResolver(() => Number)
-  async progressPercentage(@Root() challenge: Challenge): Promise<number> {
+  private async calculateProgressPercentage(
+    challenge: Challenge,
+  ): Promise<number> {
     if (!challenge.participants || !challenge.ecogestures) {
       return 0;
     }
@@ -134,6 +133,7 @@ export default class ChallengeResolver {
       where: {
         user: { id: In(participantIds) },
         ecogesture: { id: In(ecogestureIds) },
+        challenge: { id: challenge.id },
       },
     });
 
@@ -167,6 +167,8 @@ export default class ChallengeResolver {
     const queryBuilder = Challenge.createQueryBuilder("challenge")
       .leftJoinAndSelect("challenge.createdBy", "createdBy")
       .leftJoinAndSelect("challenge.participants", "participants")
+      .leftJoinAndSelect("challenge.ecogestures", "ecogestures")
+      .leftJoinAndSelect("participants.user", "user")
       .skip(skip)
       .take(limit);
 
@@ -187,6 +189,12 @@ export default class ChallengeResolver {
         .andWhere("participants.userId = :userId", { userId: ctx.user.id });
     }
     const [challenges, totalCount] = await queryBuilder.getManyAndCount();
+
+    // Calculate progressPercentage for each challenge
+    for (const challenge of challenges) {
+      challenge.progressPercentage =
+        await this.calculateProgressPercentage(challenge);
+    }
 
     return { totalCount, challenges };
   }
@@ -307,12 +315,21 @@ export default class ChallengeResolver {
   async getChallengeById(@Arg("id") id: number): Promise<Challenge> {
     const challenge = await Challenge.findOne({
       where: { id },
-      relations: ["ecogestures", "participants", "createdBy"],
+      relations: [
+        "ecogestures",
+        "participants",
+        "participants.user",
+        "createdBy",
+      ],
     });
 
     if (!challenge) {
       throw new Error("Challenge non trouvé");
     }
+
+    challenge.progressPercentage =
+      await this.calculateProgressPercentage(challenge);
+
     return challenge;
   }
 }

--- a/backend/src/resolvers/ChallengeResolver.ts
+++ b/backend/src/resolvers/ChallengeResolver.ts
@@ -180,17 +180,22 @@ export default class ChallengeResolver {
       });
     } else if (filter === ChallengeFilter.IN_PROGRESS) {
       queryBuilder
+        .innerJoin("challenge.participants", "participantFilter")
         .where("challenge.startingDate <= :now", { now })
         .andWhere("challenge.endingDate >= :now", { now })
-        .andWhere("participants.userId = :userId", { userId: ctx.user.id });
+        .andWhere("participantFilter.userId = :userId", {
+          userId: ctx.user.id,
+        });
     } else if (filter === ChallengeFilter.FINISHED) {
       queryBuilder
+        .innerJoin("challenge.participants", "participantFilter")
         .where("challenge.endingDate < :now", { now })
-        .andWhere("participants.userId = :userId", { userId: ctx.user.id });
+        .andWhere("participantFilter.userId = :userId", {
+          userId: ctx.user.id,
+        });
     }
     const [challenges, totalCount] = await queryBuilder.getManyAndCount();
 
-    // Calculate progressPercentage for each challenge
     for (const challenge of challenges) {
       challenge.progressPercentage =
         await this.calculateProgressPercentage(challenge);

--- a/backend/src/resolvers/ChallengeResolver.ts
+++ b/backend/src/resolvers/ChallengeResolver.ts
@@ -108,31 +108,28 @@ registerEnumType(ChallengeFilter, {
 
 @Resolver(Challenge)
 export default class ChallengeResolver {
-  @FieldResolver(() => Number) // ← Ajoute un champ virtuel
+  @FieldResolver(() => Number)
   async progressPercentage(@Root() challenge: Challenge): Promise<number> {
-    //nb ecogeste validé
-
-    const fullChallenge = await Challenge.findOne({
-      where: { id: challenge.id },
-      relations: ["participants", "ecogestures"],
-    });
-
-    if (!fullChallenge) {
-      throw new Error("Challenge non trouvé");
+    if (!challenge.participants || !challenge.ecogestures) {
+      return 0;
     }
 
-    const totalEcogestures = fullChallenge.ecogestures?.length || 0;
-    const totalParticipants = fullChallenge.participants?.length || 0;
+    const totalEcogestures = challenge.ecogestures?.length || 0;
+    const totalParticipants = challenge.participants?.length || 0;
 
     if (totalEcogestures === 0 || totalParticipants === 0) {
-      return 0; // Évite la division par zéro
+      return 0;
     }
 
-    const ecogestureIds = fullChallenge.ecogestures?.map((e) => e.id) || [];
+    const ecogestureIds = challenge.ecogestures?.map((e) => e.id) || [];
     const participantIds =
-      fullChallenge.participants?.map((p) => p.user.id) || [];
+      challenge.participants?.filter((p) => p.user)?.map((p) => p.user.id) ||
+      [];
 
-    // Compter combien de fois les participants ont validé les écogestes du challenge
+    if (participantIds.length === 0) {
+      return 0;
+    }
+
     const totalValidations = await UserEcogesture.count({
       where: {
         user: { id: In(participantIds) },

--- a/frontend/src/generated/graphql-types.ts
+++ b/frontend/src/generated/graphql-types.ts
@@ -1,149 +1,157 @@
-import { gql } from '@apollo/client';
-import * as Apollo from '@apollo/client';
+import { gql } from "@apollo/client";
+import * as Apollo from "@apollo/client";
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T,
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never;
+    };
 const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  DateTimeISO: { input: any; output: any; }
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  DateTimeISO: { input: any; output: any };
 };
 
 export type Challenge = {
-  __typename?: 'Challenge';
-  createdAt: Scalars['DateTimeISO']['output'];
+  __typename?: "Challenge";
+  createdAt: Scalars["DateTimeISO"]["output"];
   createdBy: User;
-  description?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars["String"]["output"]>;
   ecogestures?: Maybe<Array<Ecogesture>>;
-  endingDate: Scalars['DateTimeISO']['output'];
-  id: Scalars['Float']['output'];
-  label: Scalars['String']['output'];
+  endingDate: Scalars["DateTimeISO"]["output"];
+  id: Scalars["Float"]["output"];
+  label: Scalars["String"]["output"];
   participants: Array<UserChallenge>;
-  pictureUrl: Scalars['String']['output'];
-  startingDate: Scalars['DateTimeISO']['output'];
-  updatedAt: Scalars['DateTimeISO']['output'];
+  pictureUrl: Scalars["String"]["output"];
+  progressPercentage: Scalars["Float"]["output"];
+  startingDate: Scalars["DateTimeISO"]["output"];
+  updatedAt: Scalars["DateTimeISO"]["output"];
 };
 
 /** Filter used on Challenge */
 export enum ChallengeFilter {
-  CreatedByMe = 'CREATED_BY_ME',
-  Finished = 'FINISHED',
-  InProgress = 'IN_PROGRESS'
+  CreatedByMe = "CREATED_BY_ME",
+  Finished = "FINISHED",
+  InProgress = "IN_PROGRESS",
 }
 
 export type ChallengeListResponse = {
-  __typename?: 'ChallengeListResponse';
+  __typename?: "ChallengeListResponse";
   challenges: Array<Challenge>;
-  totalCount: Scalars['Float']['output'];
+  totalCount: Scalars["Float"]["output"];
 };
 
 export type Ecogesture = {
-  __typename?: 'Ecogesture';
+  __typename?: "Ecogesture";
   challenges?: Maybe<Array<Challenge>>;
-  createdAt: Scalars['DateTimeISO']['output'];
-  description: Scalars['String']['output'];
-  id: Scalars['Float']['output'];
-  label: Scalars['String']['output'];
-  level1Expectation: Scalars['String']['output'];
-  level2Expectation: Scalars['String']['output'];
-  level3Expectation: Scalars['String']['output'];
-  pictureUrl: Scalars['String']['output'];
-  updatedAt: Scalars['DateTimeISO']['output'];
+  createdAt: Scalars["DateTimeISO"]["output"];
+  description: Scalars["String"]["output"];
+  id: Scalars["Float"]["output"];
+  label: Scalars["String"]["output"];
+  level1Expectation: Scalars["String"]["output"];
+  level2Expectation: Scalars["String"]["output"];
+  level3Expectation: Scalars["String"]["output"];
+  pictureUrl: Scalars["String"]["output"];
+  updatedAt: Scalars["DateTimeISO"]["output"];
 };
 
 export type EcogestureListResponse = {
-  __typename?: 'EcogestureListResponse';
+  __typename?: "EcogestureListResponse";
   ecogestures: Array<Ecogesture>;
-  totalCount: Scalars['Float']['output'];
+  totalCount: Scalars["Float"]["output"];
 };
 
 export type GetEcogesturesInput = {
-  limit?: InputMaybe<Scalars['Float']['input']>;
-  page?: InputMaybe<Scalars['Float']['input']>;
+  limit?: InputMaybe<Scalars["Float"]["input"]>;
+  page?: InputMaybe<Scalars["Float"]["input"]>;
 };
 
 export type GetMyChallengesInput = {
   filter?: InputMaybe<ChallengeFilter>;
-  limit?: InputMaybe<Scalars['Float']['input']>;
-  page?: InputMaybe<Scalars['Float']['input']>;
+  limit?: InputMaybe<Scalars["Float"]["input"]>;
+  page?: InputMaybe<Scalars["Float"]["input"]>;
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
-  cleanEcogestures: Scalars['Boolean']['output'];
+  __typename?: "Mutation";
+  cleanEcogestures: Scalars["Boolean"]["output"];
   createChallenge: Challenge;
-  login: Scalars['String']['output'];
-  logout: Scalars['String']['output'];
+  login: Scalars["String"]["output"];
+  logout: Scalars["String"]["output"];
   seedEcogestures: Array<Ecogesture>;
-  signup: Scalars['String']['output'];
+  signup: Scalars["String"]["output"];
   updateChallengePicture: Challenge;
   updateProfilePicture: User;
   validateEcogesture: UserEcogesture;
 };
 
-
 export type MutationCreateChallengeArgs = {
   data: NewChallengeInput;
 };
-
 
 export type MutationLoginArgs = {
   data: NewUserInput;
 };
 
-
 export type MutationSignupArgs = {
   data: NewUserInput;
 };
-
 
 export type MutationUpdateChallengePictureArgs = {
   data: UpdateChallengePictureInput;
 };
 
-
 export type MutationUpdateProfilePictureArgs = {
   data: UpdateProfilePictureInput;
 };
 
-
 export type MutationValidateEcogestureArgs = {
-  challengeId?: InputMaybe<Scalars['Int']['input']>;
-  ecogestureId: Scalars['Int']['input'];
-  level_validated: Scalars['Int']['input'];
+  challengeId?: InputMaybe<Scalars["Int"]["input"]>;
+  ecogestureId: Scalars["Int"]["input"];
+  level_validated: Scalars["Int"]["input"];
 };
 
 export type NewChallengeInput = {
-  description?: InputMaybe<Scalars['String']['input']>;
-  ecogestureIds?: InputMaybe<Array<Scalars['Float']['input']>>;
-  endingDate: Scalars['DateTimeISO']['input'];
-  label: Scalars['String']['input'];
-  participantIds?: InputMaybe<Array<Scalars['Float']['input']>>;
-  pictureUrl: Scalars['String']['input'];
-  startingDate: Scalars['DateTimeISO']['input'];
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  ecogestureIds?: InputMaybe<Array<Scalars["Float"]["input"]>>;
+  endingDate: Scalars["DateTimeISO"]["input"];
+  label: Scalars["String"]["input"];
+  participantIds?: InputMaybe<Array<Scalars["Float"]["input"]>>;
+  pictureUrl: Scalars["String"]["input"];
+  startingDate: Scalars["DateTimeISO"]["input"];
 };
 
 export type NewUserInput = {
-  email: Scalars['String']['input'];
-  password: Scalars['String']['input'];
+  email: Scalars["String"]["input"];
+  password: Scalars["String"]["input"];
 };
 
 export type PaginationInput = {
-  limit?: InputMaybe<Scalars['Float']['input']>;
-  page?: InputMaybe<Scalars['Float']['input']>;
+  limit?: InputMaybe<Scalars["Float"]["input"]>;
+  page?: InputMaybe<Scalars["Float"]["input"]>;
 };
 
 export type Query = {
-  __typename?: 'Query';
+  __typename?: "Query";
   getAllChallenges: Array<Challenge>;
   getAllUsers: Array<User>;
   getChallengeById: Challenge;
@@ -154,91 +162,86 @@ export type Query = {
   searchUsers: SearchUsersResponse;
 };
 
-
 export type QueryGetChallengeByIdArgs = {
-  id: Scalars['Float']['input'];
+  id: Scalars["Float"]["input"];
 };
-
 
 export type QueryGetEcogesturesArgs = {
   input?: InputMaybe<GetEcogesturesInput>;
 };
 
-
 export type QueryGetMyChallengesArgs = {
   input?: InputMaybe<GetMyChallengesInput>;
 };
-
 
 export type QueryGetValidatedEcogesturesArgs = {
   input?: InputMaybe<PaginationInput>;
 };
 
-
 export type QuerySearchUsersArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  page?: InputMaybe<Scalars['Int']['input']>;
-  search: Scalars['String']['input'];
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  page?: InputMaybe<Scalars["Int"]["input"]>;
+  search: Scalars["String"]["input"];
 };
 
 /** Roles for users in this app */
 export enum Roles {
-  User = 'USER'
+  User = "USER",
 }
 
 export type SearchUsersResponse = {
-  __typename?: 'SearchUsersResponse';
-  totalCount: Scalars['Int']['output'];
+  __typename?: "SearchUsersResponse";
+  totalCount: Scalars["Int"]["output"];
   users: Array<User>;
 };
 
 export type UpdateChallengePictureInput = {
-  id: Scalars['Float']['input'];
-  pictureUrl: Scalars['String']['input'];
+  id: Scalars["Float"]["input"];
+  pictureUrl: Scalars["String"]["input"];
 };
 
 export type UpdateProfilePictureInput = {
-  pictureUrl: Scalars['String']['input'];
+  pictureUrl: Scalars["String"]["input"];
 };
 
 export type User = {
-  __typename?: 'User';
+  __typename?: "User";
   challengesCreated?: Maybe<Array<Challenge>>;
-  createdAt: Scalars['DateTimeISO']['output'];
-  email: Scalars['String']['output'];
-  id: Scalars['Float']['output'];
+  createdAt: Scalars["DateTimeISO"]["output"];
+  email: Scalars["String"]["output"];
+  id: Scalars["Float"]["output"];
   participations?: Maybe<Array<UserChallenge>>;
-  pictureUrl: Scalars['String']['output'];
+  pictureUrl: Scalars["String"]["output"];
   roles: Array<Roles>;
-  updatedAt: Scalars['DateTimeISO']['output'];
-  username: Scalars['String']['output'];
+  updatedAt: Scalars["DateTimeISO"]["output"];
+  username: Scalars["String"]["output"];
 };
 
 export type UserChallenge = {
-  __typename?: 'UserChallenge';
+  __typename?: "UserChallenge";
   challenge: Challenge;
-  createdAt: Scalars['DateTimeISO']['output'];
-  hasAccepted: Scalars['Boolean']['output'];
-  id: Scalars['Float']['output'];
-  updatedAt: Scalars['DateTimeISO']['output'];
+  createdAt: Scalars["DateTimeISO"]["output"];
+  hasAccepted: Scalars["Boolean"]["output"];
+  id: Scalars["Float"]["output"];
+  updatedAt: Scalars["DateTimeISO"]["output"];
   user: User;
 };
 
 export type UserEcogesture = {
-  __typename?: 'UserEcogesture';
+  __typename?: "UserEcogesture";
   challenge?: Maybe<Challenge>;
-  createdAt: Scalars['DateTimeISO']['output'];
+  createdAt: Scalars["DateTimeISO"]["output"];
   ecogesture: Ecogesture;
-  id: Scalars['Float']['output'];
-  level_validated: Scalars['Float']['output'];
-  updatedAt: Scalars['DateTimeISO']['output'];
+  id: Scalars["Float"]["output"];
+  level_validated: Scalars["Float"]["output"];
+  updatedAt: Scalars["DateTimeISO"]["output"];
   user: User;
-  validated_at: Scalars['DateTimeISO']['output'];
+  validated_at: Scalars["DateTimeISO"]["output"];
 };
 
 export type ValidatedEcogesturesResponse = {
-  __typename?: 'ValidatedEcogesturesResponse';
-  totalCount: Scalars['Int']['output'];
+  __typename?: "ValidatedEcogesturesResponse";
+  totalCount: Scalars["Int"]["output"];
   userEcogestures: Array<UserEcogesture>;
 };
 
@@ -246,126 +249,280 @@ export type CreateChallengeMutationVariables = Exact<{
   data: NewChallengeInput;
 }>;
 
-
-export type CreateChallengeMutation = { __typename?: 'Mutation', createChallenge: { __typename?: 'Challenge', id: number, label: string, description?: string | null, startingDate: any, endingDate: any, pictureUrl: string, createdBy: { __typename?: 'User', id: number, username: string }, ecogestures?: Array<{ __typename?: 'Ecogesture', id: number, label: string, pictureUrl: string }> | null } };
+export type CreateChallengeMutation = {
+  __typename?: "Mutation";
+  createChallenge: {
+    __typename?: "Challenge";
+    id: number;
+    label: string;
+    description?: string | null;
+    startingDate: any;
+    endingDate: any;
+    pictureUrl: string;
+    progressPercentage: number;
+    createdBy: { __typename?: "User"; id: number; username: string };
+    ecogestures?: Array<{
+      __typename?: "Ecogesture";
+      id: number;
+      label: string;
+      pictureUrl: string;
+    }> | null;
+  };
+};
 
 export type UpdateChallengePictureMutationVariables = Exact<{
   data: UpdateChallengePictureInput;
 }>;
 
+export type UpdateChallengePictureMutation = {
+  __typename?: "Mutation";
+  updateChallengePicture: {
+    __typename?: "Challenge";
+    id: number;
+    label: string;
+    pictureUrl: string;
+  };
+};
 
-export type UpdateChallengePictureMutation = { __typename?: 'Mutation', updateChallengePicture: { __typename?: 'Challenge', id: number, label: string, pictureUrl: string } };
+export type SeedEcogesturesMutationVariables = Exact<{ [key: string]: never }>;
 
-export type SeedEcogesturesMutationVariables = Exact<{ [key: string]: never; }>;
+export type SeedEcogesturesMutation = {
+  __typename?: "Mutation";
+  seedEcogestures: Array<{
+    __typename?: "Ecogesture";
+    id: number;
+    label: string;
+    description: string;
+    pictureUrl: string;
+    level1Expectation: string;
+    level2Expectation: string;
+    level3Expectation: string;
+  }>;
+};
 
+export type CleanEcogesturesMutationVariables = Exact<{ [key: string]: never }>;
 
-export type SeedEcogesturesMutation = { __typename?: 'Mutation', seedEcogestures: Array<{ __typename?: 'Ecogesture', id: number, label: string, description: string, pictureUrl: string, level1Expectation: string, level2Expectation: string, level3Expectation: string }> };
-
-export type CleanEcogesturesMutationVariables = Exact<{ [key: string]: never; }>;
-
-
-export type CleanEcogesturesMutation = { __typename?: 'Mutation', cleanEcogestures: boolean };
+export type CleanEcogesturesMutation = {
+  __typename?: "Mutation";
+  cleanEcogestures: boolean;
+};
 
 export type LoginMutationVariables = Exact<{
   data: NewUserInput;
 }>;
 
+export type LoginMutation = { __typename?: "Mutation"; login: string };
 
-export type LoginMutation = { __typename?: 'Mutation', login: string };
+export type LogoutMutationVariables = Exact<{ [key: string]: never }>;
 
-export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
-
-
-export type LogoutMutation = { __typename?: 'Mutation', logout: string };
+export type LogoutMutation = { __typename?: "Mutation"; logout: string };
 
 export type SignupMutationVariables = Exact<{
   data: NewUserInput;
 }>;
 
-
-export type SignupMutation = { __typename?: 'Mutation', signup: string };
+export type SignupMutation = { __typename?: "Mutation"; signup: string };
 
 export type UpdateProfilePictureMutationVariables = Exact<{
   data: UpdateProfilePictureInput;
 }>;
 
-
-export type UpdateProfilePictureMutation = { __typename?: 'Mutation', updateProfilePicture: { __typename?: 'User', id: number, username: string, email: string, pictureUrl: string } };
+export type UpdateProfilePictureMutation = {
+  __typename?: "Mutation";
+  updateProfilePicture: {
+    __typename?: "User";
+    id: number;
+    username: string;
+    email: string;
+    pictureUrl: string;
+  };
+};
 
 export type GetMyChallengesQueryVariables = Exact<{
   input?: InputMaybe<GetMyChallengesInput>;
 }>;
 
-
-export type GetMyChallengesQuery = { __typename?: 'Query', getMyChallenges: { __typename?: 'ChallengeListResponse', totalCount: number, challenges: Array<{ __typename?: 'Challenge', id: number, label: string, startingDate: any, endingDate: any, pictureUrl: string, createdBy: { __typename?: 'User', id: number, username: string }, participants: Array<{ __typename?: 'UserChallenge', id: number }> }> } };
+export type GetMyChallengesQuery = {
+  __typename?: "Query";
+  getMyChallenges: {
+    __typename?: "ChallengeListResponse";
+    totalCount: number;
+    challenges: Array<{
+      __typename?: "Challenge";
+      id: number;
+      label: string;
+      startingDate: any;
+      endingDate: any;
+      pictureUrl: string;
+      progressPercentage: number;
+      createdBy: { __typename?: "User"; id: number; username: string };
+      participants: Array<{ __typename?: "UserChallenge"; id: number }>;
+    }>;
+  };
+};
 
 export type GetChallengeByIdQueryVariables = Exact<{
-  getChallengeById: Scalars['Float']['input'];
+  getChallengeById: Scalars["Float"]["input"];
 }>;
 
-
-export type GetChallengeByIdQuery = { __typename?: 'Query', getChallengeById: { __typename?: 'Challenge', id: number, label: string, description?: string | null, pictureUrl: string, startingDate: any, endingDate: any, ecogestures?: Array<{ __typename?: 'Ecogesture', id: number, label: string, description: string, pictureUrl: string, level1Expectation: string, level2Expectation: string, level3Expectation: string }> | null, participants: Array<{ __typename?: 'UserChallenge', id: number }>, createdBy: { __typename?: 'User', id: number } } };
+export type GetChallengeByIdQuery = {
+  __typename?: "Query";
+  getChallengeById: {
+    __typename?: "Challenge";
+    id: number;
+    label: string;
+    description?: string | null;
+    pictureUrl: string;
+    startingDate: any;
+    endingDate: any;
+    ecogestures?: Array<{
+      __typename?: "Ecogesture";
+      id: number;
+      label: string;
+      description: string;
+      pictureUrl: string;
+      level1Expectation: string;
+      level2Expectation: string;
+      level3Expectation: string;
+    }> | null;
+    participants: Array<{ __typename?: "UserChallenge"; id: number }>;
+    createdBy: { __typename?: "User"; id: number };
+  };
+};
 
 export type GetEcogesturesQueryVariables = Exact<{
   input?: InputMaybe<GetEcogesturesInput>;
 }>;
 
-
-export type GetEcogesturesQuery = { __typename?: 'Query', getEcogestures: { __typename?: 'EcogestureListResponse', totalCount: number, ecogestures: Array<{ __typename?: 'Ecogesture', id: number, label: string, description: string, pictureUrl: string, level1Expectation: string, level2Expectation: string, level3Expectation: string }> } };
+export type GetEcogesturesQuery = {
+  __typename?: "Query";
+  getEcogestures: {
+    __typename?: "EcogestureListResponse";
+    totalCount: number;
+    ecogestures: Array<{
+      __typename?: "Ecogesture";
+      id: number;
+      label: string;
+      description: string;
+      pictureUrl: string;
+      level1Expectation: string;
+      level2Expectation: string;
+      level3Expectation: string;
+    }>;
+  };
+};
 
 export type SearchUsersQueryVariables = Exact<{
-  search: Scalars['String']['input'];
-  page?: InputMaybe<Scalars['Int']['input']>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
+  search: Scalars["String"]["input"];
+  page?: InputMaybe<Scalars["Int"]["input"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
 }>;
 
+export type SearchUsersQuery = {
+  __typename?: "Query";
+  searchUsers: {
+    __typename?: "SearchUsersResponse";
+    totalCount: number;
+    users: Array<{
+      __typename?: "User";
+      id: number;
+      username: string;
+      email: string;
+      pictureUrl: string;
+    }>;
+  };
+};
 
-export type SearchUsersQuery = { __typename?: 'Query', searchUsers: { __typename?: 'SearchUsersResponse', totalCount: number, users: Array<{ __typename?: 'User', id: number, username: string, email: string, pictureUrl: string }> } };
+export type GetCurrentUserQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetCurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetCurrentUserQuery = { __typename?: 'Query', getCurrentUser: { __typename?: 'User', id: number, email: string, username: string, roles: Array<Roles>, pictureUrl: string } };
+export type GetCurrentUserQuery = {
+  __typename?: "Query";
+  getCurrentUser: {
+    __typename?: "User";
+    id: number;
+    email: string;
+    username: string;
+    roles: Array<Roles>;
+    pictureUrl: string;
+  };
+};
 
 export type GetValidatedEcogesturesQueryVariables = Exact<{
   input: PaginationInput;
 }>;
 
-
-export type GetValidatedEcogesturesQuery = { __typename?: 'Query', getValidatedEcogestures: { __typename?: 'ValidatedEcogesturesResponse', totalCount: number, userEcogestures: Array<{ __typename?: 'UserEcogesture', id: number, validated_at: any, level_validated: number, ecogesture: { __typename?: 'Ecogesture', id: number, label: string, pictureUrl: string }, user: { __typename?: 'User', id: number }, challenge?: { __typename?: 'Challenge', id: number } | null }> } };
+export type GetValidatedEcogesturesQuery = {
+  __typename?: "Query";
+  getValidatedEcogestures: {
+    __typename?: "ValidatedEcogesturesResponse";
+    totalCount: number;
+    userEcogestures: Array<{
+      __typename?: "UserEcogesture";
+      id: number;
+      validated_at: any;
+      level_validated: number;
+      ecogesture: {
+        __typename?: "Ecogesture";
+        id: number;
+        label: string;
+        pictureUrl: string;
+      };
+      user: { __typename?: "User"; id: number };
+      challenge?: { __typename?: "Challenge"; id: number } | null;
+    }>;
+  };
+};
 
 export type ValidateEcogestureMutationVariables = Exact<{
-  ecogestureId: Scalars['Int']['input'];
-  level_validated: Scalars['Int']['input'];
-  challengeId?: InputMaybe<Scalars['Int']['input']>;
+  ecogestureId: Scalars["Int"]["input"];
+  level_validated: Scalars["Int"]["input"];
+  challengeId?: InputMaybe<Scalars["Int"]["input"]>;
 }>;
 
-
-export type ValidateEcogestureMutation = { __typename?: 'Mutation', validateEcogesture: { __typename?: 'UserEcogesture', id: number, validated_at: any, level_validated: number, ecogesture: { __typename?: 'Ecogesture', id: number, label: string, pictureUrl: string }, user: { __typename?: 'User', id: number }, challenge?: { __typename?: 'Challenge', id: number } | null } };
-
+export type ValidateEcogestureMutation = {
+  __typename?: "Mutation";
+  validateEcogesture: {
+    __typename?: "UserEcogesture";
+    id: number;
+    validated_at: any;
+    level_validated: number;
+    ecogesture: {
+      __typename?: "Ecogesture";
+      id: number;
+      label: string;
+      pictureUrl: string;
+    };
+    user: { __typename?: "User"; id: number };
+    challenge?: { __typename?: "Challenge"; id: number } | null;
+  };
+};
 
 export const CreateChallengeDocument = gql`
-    mutation CreateChallenge($data: NewChallengeInput!) {
-  createChallenge(data: $data) {
-    id
-    label
-    description
-    startingDate
-    endingDate
-    pictureUrl
-    createdBy {
-      id
-      username
-    }
-    ecogestures {
+  mutation CreateChallenge($data: NewChallengeInput!) {
+    createChallenge(data: $data) {
       id
       label
+      description
+      startingDate
+      endingDate
       pictureUrl
+      progressPercentage
+      createdBy {
+        id
+        username
+      }
+      ecogestures {
+        id
+        label
+        pictureUrl
+      }
     }
   }
-}
-    `;
-export type CreateChallengeMutationFn = Apollo.MutationFunction<CreateChallengeMutation, CreateChallengeMutationVariables>;
+`;
+export type CreateChallengeMutationFn = Apollo.MutationFunction<
+  CreateChallengeMutation,
+  CreateChallengeMutationVariables
+>;
 
 /**
  * __useCreateChallengeMutation__
@@ -384,23 +541,40 @@ export type CreateChallengeMutationFn = Apollo.MutationFunction<CreateChallengeM
  *   },
  * });
  */
-export function useCreateChallengeMutation(baseOptions?: Apollo.MutationHookOptions<CreateChallengeMutation, CreateChallengeMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateChallengeMutation, CreateChallengeMutationVariables>(CreateChallengeDocument, options);
-      }
-export type CreateChallengeMutationHookResult = ReturnType<typeof useCreateChallengeMutation>;
-export type CreateChallengeMutationResult = Apollo.MutationResult<CreateChallengeMutation>;
-export type CreateChallengeMutationOptions = Apollo.BaseMutationOptions<CreateChallengeMutation, CreateChallengeMutationVariables>;
-export const UpdateChallengePictureDocument = gql`
-    mutation UpdateChallengePicture($data: UpdateChallengePictureInput!) {
-  updateChallengePicture(data: $data) {
-    id
-    label
-    pictureUrl
-  }
+export function useCreateChallengeMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables
+  >(CreateChallengeDocument, options);
 }
-    `;
-export type UpdateChallengePictureMutationFn = Apollo.MutationFunction<UpdateChallengePictureMutation, UpdateChallengePictureMutationVariables>;
+export type CreateChallengeMutationHookResult = ReturnType<
+  typeof useCreateChallengeMutation
+>;
+export type CreateChallengeMutationResult =
+  Apollo.MutationResult<CreateChallengeMutation>;
+export type CreateChallengeMutationOptions = Apollo.BaseMutationOptions<
+  CreateChallengeMutation,
+  CreateChallengeMutationVariables
+>;
+export const UpdateChallengePictureDocument = gql`
+  mutation UpdateChallengePicture($data: UpdateChallengePictureInput!) {
+    updateChallengePicture(data: $data) {
+      id
+      label
+      pictureUrl
+    }
+  }
+`;
+export type UpdateChallengePictureMutationFn = Apollo.MutationFunction<
+  UpdateChallengePictureMutation,
+  UpdateChallengePictureMutationVariables
+>;
 
 /**
  * __useUpdateChallengePictureMutation__
@@ -419,27 +593,44 @@ export type UpdateChallengePictureMutationFn = Apollo.MutationFunction<UpdateCha
  *   },
  * });
  */
-export function useUpdateChallengePictureMutation(baseOptions?: Apollo.MutationHookOptions<UpdateChallengePictureMutation, UpdateChallengePictureMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateChallengePictureMutation, UpdateChallengePictureMutationVariables>(UpdateChallengePictureDocument, options);
-      }
-export type UpdateChallengePictureMutationHookResult = ReturnType<typeof useUpdateChallengePictureMutation>;
-export type UpdateChallengePictureMutationResult = Apollo.MutationResult<UpdateChallengePictureMutation>;
-export type UpdateChallengePictureMutationOptions = Apollo.BaseMutationOptions<UpdateChallengePictureMutation, UpdateChallengePictureMutationVariables>;
-export const SeedEcogesturesDocument = gql`
-    mutation SeedEcogestures {
-  seedEcogestures {
-    id
-    label
-    description
-    pictureUrl
-    level1Expectation
-    level2Expectation
-    level3Expectation
-  }
+export function useUpdateChallengePictureMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateChallengePictureMutation,
+    UpdateChallengePictureMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    UpdateChallengePictureMutation,
+    UpdateChallengePictureMutationVariables
+  >(UpdateChallengePictureDocument, options);
 }
-    `;
-export type SeedEcogesturesMutationFn = Apollo.MutationFunction<SeedEcogesturesMutation, SeedEcogesturesMutationVariables>;
+export type UpdateChallengePictureMutationHookResult = ReturnType<
+  typeof useUpdateChallengePictureMutation
+>;
+export type UpdateChallengePictureMutationResult =
+  Apollo.MutationResult<UpdateChallengePictureMutation>;
+export type UpdateChallengePictureMutationOptions = Apollo.BaseMutationOptions<
+  UpdateChallengePictureMutation,
+  UpdateChallengePictureMutationVariables
+>;
+export const SeedEcogesturesDocument = gql`
+  mutation SeedEcogestures {
+    seedEcogestures {
+      id
+      label
+      description
+      pictureUrl
+      level1Expectation
+      level2Expectation
+      level3Expectation
+    }
+  }
+`;
+export type SeedEcogesturesMutationFn = Apollo.MutationFunction<
+  SeedEcogesturesMutation,
+  SeedEcogesturesMutationVariables
+>;
 
 /**
  * __useSeedEcogesturesMutation__
@@ -457,19 +648,36 @@ export type SeedEcogesturesMutationFn = Apollo.MutationFunction<SeedEcogesturesM
  *   },
  * });
  */
-export function useSeedEcogesturesMutation(baseOptions?: Apollo.MutationHookOptions<SeedEcogesturesMutation, SeedEcogesturesMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<SeedEcogesturesMutation, SeedEcogesturesMutationVariables>(SeedEcogesturesDocument, options);
-      }
-export type SeedEcogesturesMutationHookResult = ReturnType<typeof useSeedEcogesturesMutation>;
-export type SeedEcogesturesMutationResult = Apollo.MutationResult<SeedEcogesturesMutation>;
-export type SeedEcogesturesMutationOptions = Apollo.BaseMutationOptions<SeedEcogesturesMutation, SeedEcogesturesMutationVariables>;
-export const CleanEcogesturesDocument = gql`
-    mutation CleanEcogestures {
-  cleanEcogestures
+export function useSeedEcogesturesMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    SeedEcogesturesMutation,
+    SeedEcogesturesMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    SeedEcogesturesMutation,
+    SeedEcogesturesMutationVariables
+  >(SeedEcogesturesDocument, options);
 }
-    `;
-export type CleanEcogesturesMutationFn = Apollo.MutationFunction<CleanEcogesturesMutation, CleanEcogesturesMutationVariables>;
+export type SeedEcogesturesMutationHookResult = ReturnType<
+  typeof useSeedEcogesturesMutation
+>;
+export type SeedEcogesturesMutationResult =
+  Apollo.MutationResult<SeedEcogesturesMutation>;
+export type SeedEcogesturesMutationOptions = Apollo.BaseMutationOptions<
+  SeedEcogesturesMutation,
+  SeedEcogesturesMutationVariables
+>;
+export const CleanEcogesturesDocument = gql`
+  mutation CleanEcogestures {
+    cleanEcogestures
+  }
+`;
+export type CleanEcogesturesMutationFn = Apollo.MutationFunction<
+  CleanEcogesturesMutation,
+  CleanEcogesturesMutationVariables
+>;
 
 /**
  * __useCleanEcogesturesMutation__
@@ -487,19 +695,36 @@ export type CleanEcogesturesMutationFn = Apollo.MutationFunction<CleanEcogesture
  *   },
  * });
  */
-export function useCleanEcogesturesMutation(baseOptions?: Apollo.MutationHookOptions<CleanEcogesturesMutation, CleanEcogesturesMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CleanEcogesturesMutation, CleanEcogesturesMutationVariables>(CleanEcogesturesDocument, options);
-      }
-export type CleanEcogesturesMutationHookResult = ReturnType<typeof useCleanEcogesturesMutation>;
-export type CleanEcogesturesMutationResult = Apollo.MutationResult<CleanEcogesturesMutation>;
-export type CleanEcogesturesMutationOptions = Apollo.BaseMutationOptions<CleanEcogesturesMutation, CleanEcogesturesMutationVariables>;
-export const LoginDocument = gql`
-    mutation login($data: NewUserInput!) {
-  login(data: $data)
+export function useCleanEcogesturesMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CleanEcogesturesMutation,
+    CleanEcogesturesMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    CleanEcogesturesMutation,
+    CleanEcogesturesMutationVariables
+  >(CleanEcogesturesDocument, options);
 }
-    `;
-export type LoginMutationFn = Apollo.MutationFunction<LoginMutation, LoginMutationVariables>;
+export type CleanEcogesturesMutationHookResult = ReturnType<
+  typeof useCleanEcogesturesMutation
+>;
+export type CleanEcogesturesMutationResult =
+  Apollo.MutationResult<CleanEcogesturesMutation>;
+export type CleanEcogesturesMutationOptions = Apollo.BaseMutationOptions<
+  CleanEcogesturesMutation,
+  CleanEcogesturesMutationVariables
+>;
+export const LoginDocument = gql`
+  mutation login($data: NewUserInput!) {
+    login(data: $data)
+  }
+`;
+export type LoginMutationFn = Apollo.MutationFunction<
+  LoginMutation,
+  LoginMutationVariables
+>;
 
 /**
  * __useLoginMutation__
@@ -518,19 +743,33 @@ export type LoginMutationFn = Apollo.MutationFunction<LoginMutation, LoginMutati
  *   },
  * });
  */
-export function useLoginMutation(baseOptions?: Apollo.MutationHookOptions<LoginMutation, LoginMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument, options);
-      }
+export function useLoginMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    LoginMutation,
+    LoginMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<LoginMutation, LoginMutationVariables>(
+    LoginDocument,
+    options,
+  );
+}
 export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
 export type LoginMutationResult = Apollo.MutationResult<LoginMutation>;
-export type LoginMutationOptions = Apollo.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
+export type LoginMutationOptions = Apollo.BaseMutationOptions<
+  LoginMutation,
+  LoginMutationVariables
+>;
 export const LogoutDocument = gql`
-    mutation Logout {
-  logout
-}
-    `;
-export type LogoutMutationFn = Apollo.MutationFunction<LogoutMutation, LogoutMutationVariables>;
+  mutation Logout {
+    logout
+  }
+`;
+export type LogoutMutationFn = Apollo.MutationFunction<
+  LogoutMutation,
+  LogoutMutationVariables
+>;
 
 /**
  * __useLogoutMutation__
@@ -548,19 +787,33 @@ export type LogoutMutationFn = Apollo.MutationFunction<LogoutMutation, LogoutMut
  *   },
  * });
  */
-export function useLogoutMutation(baseOptions?: Apollo.MutationHookOptions<LogoutMutation, LogoutMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<LogoutMutation, LogoutMutationVariables>(LogoutDocument, options);
-      }
+export function useLogoutMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    LogoutMutation,
+    LogoutMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<LogoutMutation, LogoutMutationVariables>(
+    LogoutDocument,
+    options,
+  );
+}
 export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>;
 export type LogoutMutationResult = Apollo.MutationResult<LogoutMutation>;
-export type LogoutMutationOptions = Apollo.BaseMutationOptions<LogoutMutation, LogoutMutationVariables>;
+export type LogoutMutationOptions = Apollo.BaseMutationOptions<
+  LogoutMutation,
+  LogoutMutationVariables
+>;
 export const SignupDocument = gql`
-    mutation Signup($data: NewUserInput!) {
-  signup(data: $data)
-}
-    `;
-export type SignupMutationFn = Apollo.MutationFunction<SignupMutation, SignupMutationVariables>;
+  mutation Signup($data: NewUserInput!) {
+    signup(data: $data)
+  }
+`;
+export type SignupMutationFn = Apollo.MutationFunction<
+  SignupMutation,
+  SignupMutationVariables
+>;
 
 /**
  * __useSignupMutation__
@@ -579,24 +832,38 @@ export type SignupMutationFn = Apollo.MutationFunction<SignupMutation, SignupMut
  *   },
  * });
  */
-export function useSignupMutation(baseOptions?: Apollo.MutationHookOptions<SignupMutation, SignupMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<SignupMutation, SignupMutationVariables>(SignupDocument, options);
-      }
+export function useSignupMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    SignupMutation,
+    SignupMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<SignupMutation, SignupMutationVariables>(
+    SignupDocument,
+    options,
+  );
+}
 export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>;
 export type SignupMutationResult = Apollo.MutationResult<SignupMutation>;
-export type SignupMutationOptions = Apollo.BaseMutationOptions<SignupMutation, SignupMutationVariables>;
+export type SignupMutationOptions = Apollo.BaseMutationOptions<
+  SignupMutation,
+  SignupMutationVariables
+>;
 export const UpdateProfilePictureDocument = gql`
-    mutation UpdateProfilePicture($data: UpdateProfilePictureInput!) {
-  updateProfilePicture(data: $data) {
-    id
-    username
-    email
-    pictureUrl
+  mutation UpdateProfilePicture($data: UpdateProfilePictureInput!) {
+    updateProfilePicture(data: $data) {
+      id
+      username
+      email
+      pictureUrl
+    }
   }
-}
-    `;
-export type UpdateProfilePictureMutationFn = Apollo.MutationFunction<UpdateProfilePictureMutation, UpdateProfilePictureMutationVariables>;
+`;
+export type UpdateProfilePictureMutationFn = Apollo.MutationFunction<
+  UpdateProfilePictureMutation,
+  UpdateProfilePictureMutationVariables
+>;
 
 /**
  * __useUpdateProfilePictureMutation__
@@ -615,34 +882,49 @@ export type UpdateProfilePictureMutationFn = Apollo.MutationFunction<UpdateProfi
  *   },
  * });
  */
-export function useUpdateProfilePictureMutation(baseOptions?: Apollo.MutationHookOptions<UpdateProfilePictureMutation, UpdateProfilePictureMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateProfilePictureMutation, UpdateProfilePictureMutationVariables>(UpdateProfilePictureDocument, options);
-      }
-export type UpdateProfilePictureMutationHookResult = ReturnType<typeof useUpdateProfilePictureMutation>;
-export type UpdateProfilePictureMutationResult = Apollo.MutationResult<UpdateProfilePictureMutation>;
-export type UpdateProfilePictureMutationOptions = Apollo.BaseMutationOptions<UpdateProfilePictureMutation, UpdateProfilePictureMutationVariables>;
-export const GetMyChallengesDocument = gql`
-    query GetMyChallenges($input: GetMyChallengesInput) {
-  getMyChallenges(input: $input) {
-    challenges {
-      id
-      label
-      startingDate
-      endingDate
-      pictureUrl
-      createdBy {
-        id
-        username
-      }
-      participants {
-        id
-      }
-    }
-    totalCount
-  }
+export function useUpdateProfilePictureMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateProfilePictureMutation,
+    UpdateProfilePictureMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    UpdateProfilePictureMutation,
+    UpdateProfilePictureMutationVariables
+  >(UpdateProfilePictureDocument, options);
 }
-    `;
+export type UpdateProfilePictureMutationHookResult = ReturnType<
+  typeof useUpdateProfilePictureMutation
+>;
+export type UpdateProfilePictureMutationResult =
+  Apollo.MutationResult<UpdateProfilePictureMutation>;
+export type UpdateProfilePictureMutationOptions = Apollo.BaseMutationOptions<
+  UpdateProfilePictureMutation,
+  UpdateProfilePictureMutationVariables
+>;
+export const GetMyChallengesDocument = gql`
+  query GetMyChallenges($input: GetMyChallengesInput) {
+    getMyChallenges(input: $input) {
+      challenges {
+        id
+        label
+        startingDate
+        endingDate
+        pictureUrl
+        progressPercentage
+        createdBy {
+          id
+          username
+        }
+        participants {
+          id
+        }
+      }
+      totalCount
+    }
+  }
+`;
 
 /**
  * __useGetMyChallengesQuery__
@@ -660,49 +942,87 @@ export const GetMyChallengesDocument = gql`
  *   },
  * });
  */
-export function useGetMyChallengesQuery(baseOptions?: Apollo.QueryHookOptions<GetMyChallengesQuery, GetMyChallengesQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetMyChallengesQuery, GetMyChallengesQueryVariables>(GetMyChallengesDocument, options);
-      }
-export function useGetMyChallengesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetMyChallengesQuery, GetMyChallengesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetMyChallengesQuery, GetMyChallengesQueryVariables>(GetMyChallengesDocument, options);
-        }
-export function useGetMyChallengesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetMyChallengesQuery, GetMyChallengesQueryVariables>) {
-          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<GetMyChallengesQuery, GetMyChallengesQueryVariables>(GetMyChallengesDocument, options);
-        }
-export type GetMyChallengesQueryHookResult = ReturnType<typeof useGetMyChallengesQuery>;
-export type GetMyChallengesLazyQueryHookResult = ReturnType<typeof useGetMyChallengesLazyQuery>;
-export type GetMyChallengesSuspenseQueryHookResult = ReturnType<typeof useGetMyChallengesSuspenseQuery>;
-export type GetMyChallengesQueryResult = Apollo.QueryResult<GetMyChallengesQuery, GetMyChallengesQueryVariables>;
+export function useGetMyChallengesQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetMyChallengesQuery,
+    GetMyChallengesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetMyChallengesQuery, GetMyChallengesQueryVariables>(
+    GetMyChallengesDocument,
+    options,
+  );
+}
+export function useGetMyChallengesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetMyChallengesQuery,
+    GetMyChallengesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetMyChallengesQuery,
+    GetMyChallengesQueryVariables
+  >(GetMyChallengesDocument, options);
+}
+export function useGetMyChallengesSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetMyChallengesQuery,
+        GetMyChallengesQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetMyChallengesQuery,
+    GetMyChallengesQueryVariables
+  >(GetMyChallengesDocument, options);
+}
+export type GetMyChallengesQueryHookResult = ReturnType<
+  typeof useGetMyChallengesQuery
+>;
+export type GetMyChallengesLazyQueryHookResult = ReturnType<
+  typeof useGetMyChallengesLazyQuery
+>;
+export type GetMyChallengesSuspenseQueryHookResult = ReturnType<
+  typeof useGetMyChallengesSuspenseQuery
+>;
+export type GetMyChallengesQueryResult = Apollo.QueryResult<
+  GetMyChallengesQuery,
+  GetMyChallengesQueryVariables
+>;
 export const GetChallengeByIdDocument = gql`
-    query getChallengeById($getChallengeById: Float!) {
-  getChallengeById(id: $getChallengeById) {
-    id
-    label
-    description
-    pictureUrl
-    startingDate
-    endingDate
-    ecogestures {
+  query getChallengeById($getChallengeById: Float!) {
+    getChallengeById(id: $getChallengeById) {
       id
       label
       description
       pictureUrl
-      level1Expectation
-      level2Expectation
-      level3Expectation
-    }
-    participants {
-      id
-    }
-    createdBy {
-      id
+      startingDate
+      endingDate
+      ecogestures {
+        id
+        label
+        description
+        pictureUrl
+        level1Expectation
+        level2Expectation
+        level3Expectation
+      }
+      participants {
+        id
+      }
+      createdBy {
+        id
+      }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useGetChallengeByIdQuery__
@@ -720,38 +1040,80 @@ export const GetChallengeByIdDocument = gql`
  *   },
  * });
  */
-export function useGetChallengeByIdQuery(baseOptions: Apollo.QueryHookOptions<GetChallengeByIdQuery, GetChallengeByIdQueryVariables> & ({ variables: GetChallengeByIdQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetChallengeByIdQuery, GetChallengeByIdQueryVariables>(GetChallengeByIdDocument, options);
-      }
-export function useGetChallengeByIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetChallengeByIdQuery, GetChallengeByIdQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetChallengeByIdQuery, GetChallengeByIdQueryVariables>(GetChallengeByIdDocument, options);
-        }
-export function useGetChallengeByIdSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetChallengeByIdQuery, GetChallengeByIdQueryVariables>) {
-          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<GetChallengeByIdQuery, GetChallengeByIdQueryVariables>(GetChallengeByIdDocument, options);
-        }
-export type GetChallengeByIdQueryHookResult = ReturnType<typeof useGetChallengeByIdQuery>;
-export type GetChallengeByIdLazyQueryHookResult = ReturnType<typeof useGetChallengeByIdLazyQuery>;
-export type GetChallengeByIdSuspenseQueryHookResult = ReturnType<typeof useGetChallengeByIdSuspenseQuery>;
-export type GetChallengeByIdQueryResult = Apollo.QueryResult<GetChallengeByIdQuery, GetChallengeByIdQueryVariables>;
+export function useGetChallengeByIdQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetChallengeByIdQuery,
+    GetChallengeByIdQueryVariables
+  > &
+    (
+      | { variables: GetChallengeByIdQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetChallengeByIdQuery, GetChallengeByIdQueryVariables>(
+    GetChallengeByIdDocument,
+    options,
+  );
+}
+export function useGetChallengeByIdLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetChallengeByIdQuery,
+    GetChallengeByIdQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetChallengeByIdQuery,
+    GetChallengeByIdQueryVariables
+  >(GetChallengeByIdDocument, options);
+}
+export function useGetChallengeByIdSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetChallengeByIdQuery,
+        GetChallengeByIdQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetChallengeByIdQuery,
+    GetChallengeByIdQueryVariables
+  >(GetChallengeByIdDocument, options);
+}
+export type GetChallengeByIdQueryHookResult = ReturnType<
+  typeof useGetChallengeByIdQuery
+>;
+export type GetChallengeByIdLazyQueryHookResult = ReturnType<
+  typeof useGetChallengeByIdLazyQuery
+>;
+export type GetChallengeByIdSuspenseQueryHookResult = ReturnType<
+  typeof useGetChallengeByIdSuspenseQuery
+>;
+export type GetChallengeByIdQueryResult = Apollo.QueryResult<
+  GetChallengeByIdQuery,
+  GetChallengeByIdQueryVariables
+>;
 export const GetEcogesturesDocument = gql`
-    query GetEcogestures($input: GetEcogesturesInput) {
-  getEcogestures(input: $input) {
-    totalCount
-    ecogestures {
-      id
-      label
-      description
-      pictureUrl
-      level1Expectation
-      level2Expectation
-      level3Expectation
+  query GetEcogestures($input: GetEcogesturesInput) {
+    getEcogestures(input: $input) {
+      totalCount
+      ecogestures {
+        id
+        label
+        description
+        pictureUrl
+        level1Expectation
+        level2Expectation
+        level3Expectation
+      }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useGetEcogesturesQuery__
@@ -769,35 +1131,73 @@ export const GetEcogesturesDocument = gql`
  *   },
  * });
  */
-export function useGetEcogesturesQuery(baseOptions?: Apollo.QueryHookOptions<GetEcogesturesQuery, GetEcogesturesQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetEcogesturesQuery, GetEcogesturesQueryVariables>(GetEcogesturesDocument, options);
-      }
-export function useGetEcogesturesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetEcogesturesQuery, GetEcogesturesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetEcogesturesQuery, GetEcogesturesQueryVariables>(GetEcogesturesDocument, options);
-        }
-export function useGetEcogesturesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetEcogesturesQuery, GetEcogesturesQueryVariables>) {
-          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<GetEcogesturesQuery, GetEcogesturesQueryVariables>(GetEcogesturesDocument, options);
-        }
-export type GetEcogesturesQueryHookResult = ReturnType<typeof useGetEcogesturesQuery>;
-export type GetEcogesturesLazyQueryHookResult = ReturnType<typeof useGetEcogesturesLazyQuery>;
-export type GetEcogesturesSuspenseQueryHookResult = ReturnType<typeof useGetEcogesturesSuspenseQuery>;
-export type GetEcogesturesQueryResult = Apollo.QueryResult<GetEcogesturesQuery, GetEcogesturesQueryVariables>;
+export function useGetEcogesturesQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetEcogesturesQuery,
+    GetEcogesturesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetEcogesturesQuery, GetEcogesturesQueryVariables>(
+    GetEcogesturesDocument,
+    options,
+  );
+}
+export function useGetEcogesturesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetEcogesturesQuery,
+    GetEcogesturesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GetEcogesturesQuery, GetEcogesturesQueryVariables>(
+    GetEcogesturesDocument,
+    options,
+  );
+}
+export function useGetEcogesturesSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetEcogesturesQuery,
+        GetEcogesturesQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetEcogesturesQuery,
+    GetEcogesturesQueryVariables
+  >(GetEcogesturesDocument, options);
+}
+export type GetEcogesturesQueryHookResult = ReturnType<
+  typeof useGetEcogesturesQuery
+>;
+export type GetEcogesturesLazyQueryHookResult = ReturnType<
+  typeof useGetEcogesturesLazyQuery
+>;
+export type GetEcogesturesSuspenseQueryHookResult = ReturnType<
+  typeof useGetEcogesturesSuspenseQuery
+>;
+export type GetEcogesturesQueryResult = Apollo.QueryResult<
+  GetEcogesturesQuery,
+  GetEcogesturesQueryVariables
+>;
 export const SearchUsersDocument = gql`
-    query SearchUsers($search: String!, $page: Int, $limit: Int) {
-  searchUsers(search: $search, page: $page, limit: $limit) {
-    totalCount
-    users {
-      id
-      username
-      email
-      pictureUrl
+  query SearchUsers($search: String!, $page: Int, $limit: Int) {
+    searchUsers(search: $search, page: $page, limit: $limit) {
+      totalCount
+      users {
+        id
+        username
+        email
+        pictureUrl
+      }
     }
   }
-}
-    `;
+`;
 
 /**
  * __useSearchUsersQuery__
@@ -817,33 +1217,73 @@ export const SearchUsersDocument = gql`
  *   },
  * });
  */
-export function useSearchUsersQuery(baseOptions: Apollo.QueryHookOptions<SearchUsersQuery, SearchUsersQueryVariables> & ({ variables: SearchUsersQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<SearchUsersQuery, SearchUsersQueryVariables>(SearchUsersDocument, options);
-      }
-export function useSearchUsersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SearchUsersQuery, SearchUsersQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<SearchUsersQuery, SearchUsersQueryVariables>(SearchUsersDocument, options);
-        }
-export function useSearchUsersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<SearchUsersQuery, SearchUsersQueryVariables>) {
-          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<SearchUsersQuery, SearchUsersQueryVariables>(SearchUsersDocument, options);
-        }
-export type SearchUsersQueryHookResult = ReturnType<typeof useSearchUsersQuery>;
-export type SearchUsersLazyQueryHookResult = ReturnType<typeof useSearchUsersLazyQuery>;
-export type SearchUsersSuspenseQueryHookResult = ReturnType<typeof useSearchUsersSuspenseQuery>;
-export type SearchUsersQueryResult = Apollo.QueryResult<SearchUsersQuery, SearchUsersQueryVariables>;
-export const GetCurrentUserDocument = gql`
-    query GetCurrentUser {
-  getCurrentUser {
-    id
-    email
-    username
-    roles
-    pictureUrl
-  }
+export function useSearchUsersQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    SearchUsersQuery,
+    SearchUsersQueryVariables
+  > &
+    (
+      | { variables: SearchUsersQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<SearchUsersQuery, SearchUsersQueryVariables>(
+    SearchUsersDocument,
+    options,
+  );
 }
-    `;
+export function useSearchUsersLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SearchUsersQuery,
+    SearchUsersQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<SearchUsersQuery, SearchUsersQueryVariables>(
+    SearchUsersDocument,
+    options,
+  );
+}
+export function useSearchUsersSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        SearchUsersQuery,
+        SearchUsersQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<SearchUsersQuery, SearchUsersQueryVariables>(
+    SearchUsersDocument,
+    options,
+  );
+}
+export type SearchUsersQueryHookResult = ReturnType<typeof useSearchUsersQuery>;
+export type SearchUsersLazyQueryHookResult = ReturnType<
+  typeof useSearchUsersLazyQuery
+>;
+export type SearchUsersSuspenseQueryHookResult = ReturnType<
+  typeof useSearchUsersSuspenseQuery
+>;
+export type SearchUsersQueryResult = Apollo.QueryResult<
+  SearchUsersQuery,
+  SearchUsersQueryVariables
+>;
+export const GetCurrentUserDocument = gql`
+  query GetCurrentUser {
+    getCurrentUser {
+      id
+      email
+      username
+      roles
+      pictureUrl
+    }
+  }
+`;
 
 /**
  * __useGetCurrentUserQuery__
@@ -860,45 +1300,83 @@ export const GetCurrentUserDocument = gql`
  *   },
  * });
  */
-export function useGetCurrentUserQuery(baseOptions?: Apollo.QueryHookOptions<GetCurrentUserQuery, GetCurrentUserQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetCurrentUserQuery, GetCurrentUserQueryVariables>(GetCurrentUserDocument, options);
-      }
-export function useGetCurrentUserLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetCurrentUserQuery, GetCurrentUserQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetCurrentUserQuery, GetCurrentUserQueryVariables>(GetCurrentUserDocument, options);
-        }
-export function useGetCurrentUserSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetCurrentUserQuery, GetCurrentUserQueryVariables>) {
-          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<GetCurrentUserQuery, GetCurrentUserQueryVariables>(GetCurrentUserDocument, options);
-        }
-export type GetCurrentUserQueryHookResult = ReturnType<typeof useGetCurrentUserQuery>;
-export type GetCurrentUserLazyQueryHookResult = ReturnType<typeof useGetCurrentUserLazyQuery>;
-export type GetCurrentUserSuspenseQueryHookResult = ReturnType<typeof useGetCurrentUserSuspenseQuery>;
-export type GetCurrentUserQueryResult = Apollo.QueryResult<GetCurrentUserQuery, GetCurrentUserQueryVariables>;
-export const GetValidatedEcogesturesDocument = gql`
-    query GetValidatedEcogestures($input: PaginationInput!) {
-  getValidatedEcogestures(input: $input) {
-    userEcogestures {
-      id
-      validated_at
-      level_validated
-      ecogesture {
-        id
-        label
-        pictureUrl
-      }
-      user {
-        id
-      }
-      challenge {
-        id
-      }
-    }
-    totalCount
-  }
+export function useGetCurrentUserQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetCurrentUserQuery,
+    GetCurrentUserQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetCurrentUserQuery, GetCurrentUserQueryVariables>(
+    GetCurrentUserDocument,
+    options,
+  );
 }
-    `;
+export function useGetCurrentUserLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetCurrentUserQuery,
+    GetCurrentUserQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GetCurrentUserQuery, GetCurrentUserQueryVariables>(
+    GetCurrentUserDocument,
+    options,
+  );
+}
+export function useGetCurrentUserSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetCurrentUserQuery,
+        GetCurrentUserQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetCurrentUserQuery,
+    GetCurrentUserQueryVariables
+  >(GetCurrentUserDocument, options);
+}
+export type GetCurrentUserQueryHookResult = ReturnType<
+  typeof useGetCurrentUserQuery
+>;
+export type GetCurrentUserLazyQueryHookResult = ReturnType<
+  typeof useGetCurrentUserLazyQuery
+>;
+export type GetCurrentUserSuspenseQueryHookResult = ReturnType<
+  typeof useGetCurrentUserSuspenseQuery
+>;
+export type GetCurrentUserQueryResult = Apollo.QueryResult<
+  GetCurrentUserQuery,
+  GetCurrentUserQueryVariables
+>;
+export const GetValidatedEcogesturesDocument = gql`
+  query GetValidatedEcogestures($input: PaginationInput!) {
+    getValidatedEcogestures(input: $input) {
+      userEcogestures {
+        id
+        validated_at
+        level_validated
+        ecogesture {
+          id
+          label
+          pictureUrl
+        }
+        user {
+          id
+        }
+        challenge {
+          id
+        }
+      }
+      totalCount
+    }
+  }
+`;
 
 /**
  * __useGetValidatedEcogesturesQuery__
@@ -916,47 +1394,96 @@ export const GetValidatedEcogesturesDocument = gql`
  *   },
  * });
  */
-export function useGetValidatedEcogesturesQuery(baseOptions: Apollo.QueryHookOptions<GetValidatedEcogesturesQuery, GetValidatedEcogesturesQueryVariables> & ({ variables: GetValidatedEcogesturesQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetValidatedEcogesturesQuery, GetValidatedEcogesturesQueryVariables>(GetValidatedEcogesturesDocument, options);
-      }
-export function useGetValidatedEcogesturesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetValidatedEcogesturesQuery, GetValidatedEcogesturesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetValidatedEcogesturesQuery, GetValidatedEcogesturesQueryVariables>(GetValidatedEcogesturesDocument, options);
-        }
-export function useGetValidatedEcogesturesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetValidatedEcogesturesQuery, GetValidatedEcogesturesQueryVariables>) {
-          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<GetValidatedEcogesturesQuery, GetValidatedEcogesturesQueryVariables>(GetValidatedEcogesturesDocument, options);
-        }
-export type GetValidatedEcogesturesQueryHookResult = ReturnType<typeof useGetValidatedEcogesturesQuery>;
-export type GetValidatedEcogesturesLazyQueryHookResult = ReturnType<typeof useGetValidatedEcogesturesLazyQuery>;
-export type GetValidatedEcogesturesSuspenseQueryHookResult = ReturnType<typeof useGetValidatedEcogesturesSuspenseQuery>;
-export type GetValidatedEcogesturesQueryResult = Apollo.QueryResult<GetValidatedEcogesturesQuery, GetValidatedEcogesturesQueryVariables>;
+export function useGetValidatedEcogesturesQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetValidatedEcogesturesQuery,
+    GetValidatedEcogesturesQueryVariables
+  > &
+    (
+      | { variables: GetValidatedEcogesturesQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetValidatedEcogesturesQuery,
+    GetValidatedEcogesturesQueryVariables
+  >(GetValidatedEcogesturesDocument, options);
+}
+export function useGetValidatedEcogesturesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetValidatedEcogesturesQuery,
+    GetValidatedEcogesturesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetValidatedEcogesturesQuery,
+    GetValidatedEcogesturesQueryVariables
+  >(GetValidatedEcogesturesDocument, options);
+}
+export function useGetValidatedEcogesturesSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetValidatedEcogesturesQuery,
+        GetValidatedEcogesturesQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetValidatedEcogesturesQuery,
+    GetValidatedEcogesturesQueryVariables
+  >(GetValidatedEcogesturesDocument, options);
+}
+export type GetValidatedEcogesturesQueryHookResult = ReturnType<
+  typeof useGetValidatedEcogesturesQuery
+>;
+export type GetValidatedEcogesturesLazyQueryHookResult = ReturnType<
+  typeof useGetValidatedEcogesturesLazyQuery
+>;
+export type GetValidatedEcogesturesSuspenseQueryHookResult = ReturnType<
+  typeof useGetValidatedEcogesturesSuspenseQuery
+>;
+export type GetValidatedEcogesturesQueryResult = Apollo.QueryResult<
+  GetValidatedEcogesturesQuery,
+  GetValidatedEcogesturesQueryVariables
+>;
 export const ValidateEcogestureDocument = gql`
-    mutation ValidateEcogesture($ecogestureId: Int!, $level_validated: Int!, $challengeId: Int) {
-  validateEcogesture(
-    ecogestureId: $ecogestureId
-    level_validated: $level_validated
-    challengeId: $challengeId
+  mutation ValidateEcogesture(
+    $ecogestureId: Int!
+    $level_validated: Int!
+    $challengeId: Int
   ) {
-    id
-    validated_at
-    level_validated
-    ecogesture {
+    validateEcogesture(
+      ecogestureId: $ecogestureId
+      level_validated: $level_validated
+      challengeId: $challengeId
+    ) {
       id
-      label
-      pictureUrl
-    }
-    user {
-      id
-    }
-    challenge {
-      id
+      validated_at
+      level_validated
+      ecogesture {
+        id
+        label
+        pictureUrl
+      }
+      user {
+        id
+      }
+      challenge {
+        id
+      }
     }
   }
-}
-    `;
-export type ValidateEcogestureMutationFn = Apollo.MutationFunction<ValidateEcogestureMutation, ValidateEcogestureMutationVariables>;
+`;
+export type ValidateEcogestureMutationFn = Apollo.MutationFunction<
+  ValidateEcogestureMutation,
+  ValidateEcogestureMutationVariables
+>;
 
 /**
  * __useValidateEcogestureMutation__
@@ -977,10 +1504,24 @@ export type ValidateEcogestureMutationFn = Apollo.MutationFunction<ValidateEcoge
  *   },
  * });
  */
-export function useValidateEcogestureMutation(baseOptions?: Apollo.MutationHookOptions<ValidateEcogestureMutation, ValidateEcogestureMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<ValidateEcogestureMutation, ValidateEcogestureMutationVariables>(ValidateEcogestureDocument, options);
-      }
-export type ValidateEcogestureMutationHookResult = ReturnType<typeof useValidateEcogestureMutation>;
-export type ValidateEcogestureMutationResult = Apollo.MutationResult<ValidateEcogestureMutation>;
-export type ValidateEcogestureMutationOptions = Apollo.BaseMutationOptions<ValidateEcogestureMutation, ValidateEcogestureMutationVariables>;
+export function useValidateEcogestureMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    ValidateEcogestureMutation,
+    ValidateEcogestureMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    ValidateEcogestureMutation,
+    ValidateEcogestureMutationVariables
+  >(ValidateEcogestureDocument, options);
+}
+export type ValidateEcogestureMutationHookResult = ReturnType<
+  typeof useValidateEcogestureMutation
+>;
+export type ValidateEcogestureMutationResult =
+  Apollo.MutationResult<ValidateEcogestureMutation>;
+export type ValidateEcogestureMutationOptions = Apollo.BaseMutationOptions<
+  ValidateEcogestureMutation,
+  ValidateEcogestureMutationVariables
+>;

--- a/frontend/src/graphql/mutations/challenge.ts
+++ b/frontend/src/graphql/mutations/challenge.ts
@@ -9,6 +9,7 @@ export const CREATE_CHALLENGE = gql`
       startingDate
       endingDate
       pictureUrl
+      progressPercentage
       createdBy {
         id
         username

--- a/frontend/src/graphql/queries/challenge.ts
+++ b/frontend/src/graphql/queries/challenge.ts
@@ -9,6 +9,7 @@ export const GET_MY_CHALLENGES = gql`
         startingDate
         endingDate
         pictureUrl
+        progressPercentage
         createdBy {
           id
           username

--- a/frontend/src/pages/ChallengePage/EcogestureChallengeCard.tsx
+++ b/frontend/src/pages/ChallengePage/EcogestureChallengeCard.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { TypographyH3 } from "@/components/ui/typographyH3";
 import { TypographyP } from "@/components/ui/typographyP";
 import { VALIDATE_ECOGESTURE } from "@/graphql/queries/validateEcogesture";
+import { GET_MY_CHALLENGES } from "@/graphql/queries/challenge";
 import { cn } from "@/lib/utils";
 import { useMutation } from "@apollo/client";
 import { useEffect, useState } from "react";
@@ -36,7 +37,12 @@ function EcogestureChallengeCard({
   const [loading, setLoading] = useState(false);
 
   const [validateEcogesture] = useMutation(VALIDATE_ECOGESTURE, {
-    refetchQueries: ["GetValidatedEcogestures"],
+    refetchQueries: [
+      "GetValidatedEcogestures",
+      {
+        query: GET_MY_CHALLENGES,
+      },
+    ],
     awaitRefetchQueries: true,
     onCompleted: (data) => {
       setCurrentLevel(data.validateEcogesture.level_validated);
@@ -94,8 +100,7 @@ function EcogestureChallengeCard({
         className="h-[8rem]"
       />
       {currentLevel > 0 && (
-        <div className="absolute top-2 right-2 bg-white rounded-full p-1">
-        </div>
+        <div className="absolute top-2 right-2 bg-white rounded-full p-1"></div>
       )}
       <CardContent className="p-4">
         <TypographyH3 className="mb-2 text-black">

--- a/frontend/src/pages/CreateChallengePage/NewChallenge.tsx
+++ b/frontend/src/pages/CreateChallengePage/NewChallenge.tsx
@@ -3,7 +3,6 @@ import { ApolloError, useMutation } from "@apollo/client";
 import { useNavigate } from "react-router";
 import { CREATE_CHALLENGE } from "@/graphql/mutations/challenge";
 import { GET_MY_CHALLENGES } from "@/graphql/queries/challenge";
-import { ChallengeFilter } from "@/generated/graphql-types";
 import EcogesturesSelect from "@/pages/CreateChallengePage/EcogesturesSelect";
 import {
   Card,

--- a/frontend/src/pages/CreateChallengePage/NewChallenge.tsx
+++ b/frontend/src/pages/CreateChallengePage/NewChallenge.tsx
@@ -3,6 +3,7 @@ import { ApolloError, useMutation } from "@apollo/client";
 import { useNavigate } from "react-router";
 import { CREATE_CHALLENGE } from "@/graphql/mutations/challenge";
 import { GET_MY_CHALLENGES } from "@/graphql/queries/challenge";
+import { ChallengeFilter } from "@/generated/graphql-types";
 import EcogesturesSelect from "@/pages/CreateChallengePage/EcogesturesSelect";
 import {
   Card,
@@ -44,6 +45,19 @@ function NewChallenge({
     refetchQueries: [
       {
         query: GET_MY_CHALLENGES,
+        variables: {
+          input: {
+            filter: ChallengeFilter.InProgress,
+          },
+        },
+      },
+      {
+        query: GET_MY_CHALLENGES,
+        variables: {
+          input: {
+            filter: ChallengeFilter.CreatedByMe,
+          },
+        },
       },
     ],
     awaitRefetchQueries: true,

--- a/frontend/src/pages/DashboardPage/MyChallenges.tsx/ChallengeCard.tsx
+++ b/frontend/src/pages/DashboardPage/MyChallenges.tsx/ChallengeCard.tsx
@@ -34,7 +34,7 @@ const ChallengeCard = ({ challenge, userId }: ChallengeCardProps) => {
       <Card
         className={cn(
           "w-full overflow-hidden pt-0",
-          "bg-secondary-foreground border-none shadow-2xl",,
+          "bg-secondary-foreground border-none shadow-2xl",
         )}
       >
         <div className="relative h-48 overflow-hidden">
@@ -47,7 +47,7 @@ const ChallengeCard = ({ challenge, userId }: ChallengeCardProps) => {
             className={cn(
               "absolute top-3 right-3",
               "bg-white/90 p-2 rounded-lg shadow-md",
-              "flex gap-2",,
+              "flex gap-2",
             )}
           >
             {challenge.createdBy.id === userId && (
@@ -112,11 +112,11 @@ const ChallengeCard = ({ challenge, userId }: ChallengeCardProps) => {
             </div>
           </div>
 
-            <div className="space-y-2">
+          <div className="space-y-2">
             <div className="flex justify-end">
               <span className="text-sm font-bold text-slate-900">
-              {challenge.progressPercentage}%
-            </span>
+                {challenge.progressPercentage}%
+              </span>
             </div>
             <Progress
               value={challenge.progressPercentage}

--- a/frontend/src/pages/DashboardPage/MyChallenges.tsx/ChallengeCard.tsx
+++ b/frontend/src/pages/DashboardPage/MyChallenges.tsx/ChallengeCard.tsx
@@ -34,7 +34,7 @@ const ChallengeCard = ({ challenge, userId }: ChallengeCardProps) => {
       <Card
         className={cn(
           "w-full overflow-hidden pt-0",
-          "bg-secondary-foreground border-none shadow-2xl",
+          "bg-secondary-foreground border-none shadow-2xl",,
         )}
       >
         <div className="relative h-48 overflow-hidden">
@@ -47,7 +47,7 @@ const ChallengeCard = ({ challenge, userId }: ChallengeCardProps) => {
             className={cn(
               "absolute top-3 right-3",
               "bg-white/90 p-2 rounded-lg shadow-md",
-              "flex gap-2",
+              "flex gap-2",,
             )}
           >
             {challenge.createdBy.id === userId && (
@@ -112,15 +112,16 @@ const ChallengeCard = ({ challenge, userId }: ChallengeCardProps) => {
             </div>
           </div>
 
-          {/* TODO wait for ecogeste validation to calculate the challenge progress and change the aria value with result */}
-          <div className="space-y-2">
+            <div className="space-y-2">
             <div className="flex justify-end">
-              <span className="text-sm font-bold text-slate-900">85%</span>
+              <span className="text-sm font-bold text-slate-900">
+              {challenge.progressPercentage}%
+            </span>
             </div>
             <Progress
-              value={85}
+              value={challenge.progressPercentage}
               className="h-3 bg-white/60"
-              aria-label={`Progression : ${85}%`}
+              aria-label={`Progression : ${challenge.progressPercentage}%`}
             />
           </div>
         </CardContent>


### PR DESCRIPTION
<!-- Keep the structure intact, only attempt to replace the comments based on their content, with the exception of this comment, which should not be replaced -->

❓Problem

- Le pourcentage de progression des challenges affichait une valeur hardcodée de 85% au lieu du calcul réel basé sur les écogestes validés
- Lors de la création d'un challenge, le nouveau challenge n'apparaissait pas immédiatement dans le dashboard après redirection (nécessitait un refresh manuel)

🎯 Solution

**Backend:**
- Ajout du champ `progressPercentage` à l'entité `Challenge` avec `@Expose()` de class-transformer
- Implémentation de la méthode `calculateProgressPercentage()` qui calcule le pourcentage réel en fonction :
  - Du nombre total d'écogestes validés par tous les participants pour ce challenge
  - Du nombre maximum possible de validations (nb écogestes × nb participants)
- Ajout des relations nécessaires (`ecogestures`, `participants.user`) dans les requêtes pour permettre le calcul


Problème : chaque challenge n'affichait qu'un seul participant (l'utilisateur connecté) au lieu de tous les participants car le `.andWhere("participants.userId = :userId", { userId: ctx.user.id })` filtrait les challenges retournés et les participants chargés dans la relation (on ne veut pas ça)

- Correction des requêtes avec filtres en utilisant des `innerJoin` séparés nommés `participantFilter` : cette séparation évite les conflits avec le `leftJoinAndSelect("challenge.participants", "participants")` utilisé pour charger les données. Le `innerJoin` sert uniquement au filtrage SQL tandis que le `leftJoinAndSelect` charge les relations nécessaires au calcul de progression.


**Frontend:**
- Configuration du `refetchQueries` avec les variables appropriées (filtres `InProgress` et `CreatedByMe`) pour mettre à jour les bons caches Apollo Client
- Ajout du champ `progressPercentage` dans les queries GraphQL 
- Remplacement de la valeur hardcodée `85%` par `{challenge.progressPercentage}%` dans `ChallengeCard.tsx`
- Ajout du refetch de `GET_MY_CHALLENGES` lors de la validation d'un écogeste pour mettre à jour la progression en temps réel

# 🧭 Tests

<!--
If the changes in PR are not adequately covered by automated tests, describe how you manually tested them and to what extent (including edge cases)
-->

# 🧑‍🎓 Checklist

- [ ] I have added visuals to help with the review (UI changes, test results, overview diagram, ...)
- [x] I have reviewed my own PR
